### PR TITLE
Add service detail page

### DIFF
--- a/api/get-service/[serviceId].js
+++ b/api/get-service/[serviceId].js
@@ -1,0 +1,60 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const { serviceId } = req.query
+
+    if (!serviceId) {
+      return res.status(400).json({ error: 'Service ID is required' })
+    }
+
+    const { data: service, error } = await supabase
+      .from('salon_services')
+      .select('*')
+      .eq('id', serviceId)
+      .single()
+
+    if (error) {
+      console.error('❌ Service fetch error:', error)
+      return res.status(500).json({
+        error: 'Failed to fetch service',
+        details: error.message
+      })
+    }
+
+    if (!service) {
+      return res.status(404).json({ error: 'Service not found' })
+    }
+
+    res.status(200).json({
+      success: true,
+      service,
+      timestamp: new Date().toISOString()
+    })
+
+  } catch (err) {
+    console.error('❌ Get Service Error:', err)
+    res.status(500).json({
+      error: 'Unexpected error',
+      details: err.message
+    })
+  }
+}

--- a/pages/services/[serviceId].js
+++ b/pages/services/[serviceId].js
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+
+export default function ServiceDetail() {
+  const router = useRouter()
+  const { serviceId } = router.query
+
+  const [service, setService] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!serviceId) return
+
+    const loadService = async () => {
+      try {
+        setLoading(true)
+        const res = await fetch(`/api/get-service/${serviceId}`)
+        if (!res.ok) throw new Error('Failed to load service')
+        const data = await res.json()
+        setService(data.service)
+      } catch (err) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadService()
+  }, [serviceId])
+
+  const handleImageError = (e) => {
+    if (e.target.dataset.fallbackSet === 'true') return
+
+    const width = e.target.offsetWidth || 200
+    const height = e.target.offsetHeight || 200
+
+    const svgContent = `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">` +
+      `<rect width="${width}" height="${height}" fill="#f8f9fa" stroke="#dee2e6" stroke-width="2"/>` +
+      `<text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="#999" font-family="Arial, sans-serif" font-size="14">No Image</text>` +
+      `</svg>`
+
+    e.target.src = `data:image/svg+xml;base64,${btoa(svgContent)}`
+    e.target.dataset.fallbackSet = 'true'
+  }
+
+  if (loading) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center' }}>
+        <h1>Loading service...</h1>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center', color: 'red' }}>
+        <h1>Error Loading Service</h1>
+        <p>{error}</p>
+      </div>
+    )
+  }
+
+  if (!service) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center' }}>
+        <h1>Service not found</h1>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{service.name}</title>
+      </Head>
+      <div style={{ fontFamily: 'Arial, sans-serif', backgroundColor: '#f8f9fa', minHeight: '100vh', padding: '20px' }}>
+        <button onClick={() => router.back()} style={{ marginBottom: '20px' }}>← Back</button>
+        <h1 style={{ marginTop: 0 }}>{service.name}</h1>
+        {service.image_url && (
+          <img
+            src={service.image_url}
+            alt={service.name}
+            style={{ width: '100%', maxWidth: '400px', borderRadius: '8px', marginBottom: '20px' }}
+            onError={handleImageError}
+          />
+        )}
+        {service.description && (
+          <p style={{ maxWidth: '600px', lineHeight: 1.5 }}>{service.description}</p>
+        )}
+        <p><strong>Price:</strong> ${service.price}</p>
+        <p><strong>Duration:</strong> {service.duration_minutes} minutes</p>
+      </div>
+    </>
+  )
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -845,15 +845,20 @@ export default function StaffPortal() {
                     gap: '15px'
                   }}>
                     {categoryServices.map((service) => (
-                      <div key={service.id} style={{ 
-                        background: 'white', 
-                        border: '1px solid #e9ecef', 
-                        borderRadius: '8px',
-                        padding: '20px',
-                        boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
-                        display: 'flex',
-                        gap: '15px'
-                      }}>
+                      <div
+                        key={service.id}
+                        onClick={() => router.push('/services/' + service.id)}
+                        style={{
+                          background: 'white',
+                          border: '1px solid #e9ecef',
+                          borderRadius: '8px',
+                          padding: '20px',
+                          boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
+                          display: 'flex',
+                          gap: '15px',
+                          cursor: 'pointer'
+                        }}
+                      >
                         {/* Service Image */}
                         <div style={{ 
                           width: '80px', 


### PR DESCRIPTION
## Summary
- navigate from each service card to a service detail page
- implement new page `pages/services/[serviceId].js`
- add API route `api/get-service/[serviceId].js` to fetch a single service

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850bea3ab40832a8ffd61afa467ae25