### PR TITLE
Fix extractContactId helper in booking created file

### DIFF
--- a/api/booking-created.js
+++ b/api/booking-created.js
@@ -352,5 +352,3 @@ function extractContactId(data) {
         null;
 }
   
-  return notes.length > 0 ? notes.join(' | ') : null;
-}


### PR DESCRIPTION
## Summary
- remove duplicated notes return statement at end of `booking-created.js`
- ensure `extractContactId` is last helper

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685217b0a83c832aa53ffb466e4efa0c