### PR TITLE
Remove unused product image column

### DIFF
--- a/api/upload-product-image.js
+++ b/api/upload-product-image.js
@@ -215,9 +215,8 @@ export default async function handler(req, res) {
       try {
         const { data, error: updateError } = await supabase
           .from('products')
-          .update({ 
+          .update({
             image_url: imageUrl,
-            image_uploaded_at: new Date().toISOString(),
             updated_at: new Date().toISOString()
           })
           .eq('id', productId)


### PR DESCRIPTION
## Summary
- clean up image upload update by removing `image_uploaded_at`

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685217d46128832a8440429135e63901