### PR TITLE
Add slugify helper and fallback service images

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,11 @@ CREATE TABLE service_products (
   PRIMARY KEY (service_id, product_id)
 );
 
+## 📷 Service Images
+
+Place SVG images for services in `public/images/services`.
+Each file should be named using the slugified service name
+(for example, `Cut & Style` becomes `cut-and-style.svg`).
+These images are used when a service does not specify its
+own `image_url`.
+

--- a/pages/services/[serviceId].js
+++ b/pages/services/[serviceId].js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
+import slugify from '../../utils/slugify'
 
 export default function ServiceDetail() {
   const router = useRouter()
@@ -87,14 +88,17 @@ export default function ServiceDetail() {
       >
         <button onClick={() => router.back()} style={{ marginBottom: '20px' }}>← Back</button>
         <h1 style={{ marginTop: 0 }}>{service.name}</h1>
-        {service.image_url && (
-          <img
-            src={service.image_url}
-            alt={service.name}
-            style={{ width: '100%', maxWidth: '400px', borderRadius: '8px', marginBottom: '20px' }}
-            onError={handleImageError}
-          />
-        )}
+        {(() => {
+          const localPath = `/images/services/${slugify(service.name)}.svg`
+          return (
+            <img
+              src={service.image_url || localPath}
+              alt={service.name}
+              style={{ width: '100%', maxWidth: '400px', borderRadius: '8px', marginBottom: '20px' }}
+              onError={handleImageError}
+            />
+          )
+        })()}
         {service.description && (
           <p style={{ maxWidth: '600px', lineHeight: 1.5 }}>{service.description}</p>
         )}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
+import slugify from '../utils/slugify'
 
 export default function StaffPortal() {
   const router = useRouter()
@@ -839,12 +840,14 @@ export default function StaffPortal() {
                     {category} ({categoryServices.length} services)
                   </h3>
 
-                  <div style={{ 
-                    display: 'grid', 
-                    gridTemplateColumns: 'repeat(auto-fill, minmax(350px, 1fr))', 
+                  <div style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fill, minmax(350px, 1fr))',
                     gap: '15px'
                   }}>
-                    {categoryServices.map((service) => (
+                    {categoryServices.map((service) => {
+                      const localPath = `/images/services/${slugify(service.name)}.svg`
+                      return (
                       <div
                         key={service.id}
                         onClick={() => router.push('/services/' + service.id)}
@@ -869,7 +872,7 @@ export default function StaffPortal() {
                           backgroundColor: '#f8f9fa'
                         }}>
                           <img
-                            src={service.image_url || ''}
+                            src={service.image_url || localPath}
                             alt={service.name}
                             style={{
                               width: '100%',
@@ -904,7 +907,7 @@ export default function StaffPortal() {
                           </div>
                         </div>
                       </div>
-                    ))}
+                      )})}
                   </div>
                 </div>
               ))}

--- a/utils/slugify.js
+++ b/utils/slugify.js
@@ -1,0 +1,10 @@
+export default function slugify(name = '') {
+  return name
+    .toString()
+    .toLowerCase()
+    .trim()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/--+/g, '-');
+}


### PR DESCRIPTION
## Summary
- add a `utils/slugify` helper for converting service names to URL slugs
- use the slug when loading service images in the staff portal and service details
- document where to store service images

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853694f7a5c832a9c4c792b20b481d7