### PR TITLE
Add selling price support

### DIFF
--- a/api/get-products.js
+++ b/api/get-products.js
@@ -28,7 +28,9 @@ export default async function handler(req, res) {
     
     let query = supabase
       .from('products')
-      .select('*')
+      .select(
+        'id, product_name, brand, category, size, unit_type, sku, cost_per_unit, selling_price, current_stock, min_threshold, location, image_url, description, is_active'
+      )
       .eq('is_active', true)
       .order('category')
       .order('product_name');

--- a/api/products/[id].js
+++ b/api/products/[id].js
@@ -1,0 +1,54 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const { id } = req.query
+    if (!id) {
+      return res.status(400).json({ error: 'Product ID is required' })
+    }
+
+    const { data: product, error } = await supabase
+      .from('products')
+      .select('*')
+      .eq('id', id)
+      .single()
+
+    if (error) {
+      console.error('❌ Product fetch error:', error)
+      return res.status(500).json({
+        error: 'Failed to fetch product',
+        details: error.message
+      })
+    }
+
+    if (!product) {
+      return res.status(404).json({ error: 'Product not found' })
+    }
+
+    res.status(200).json({ success: true, product })
+  } catch (err) {
+    console.error('❌ Get Product Error:', err)
+    res.status(500).json({
+      error: 'Unexpected error',
+      details: err.message
+    })
+  }
+}

--- a/migrations/20240101_add_selling_price_to_products.sql
+++ b/migrations/20240101_add_selling_price_to_products.sql
@@ -1,0 +1,2 @@
+ALTER TABLE products
+ADD COLUMN IF NOT EXISTS selling_price numeric;

--- a/pages/products/[productId].js
+++ b/pages/products/[productId].js
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import slugify from '../../utils/slugify'
+
+export default function ProductDetail() {
+  const router = useRouter()
+  const { productId } = router.query
+
+  const [product, setProduct] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!productId) return
+
+    const loadProduct = async () => {
+      try {
+        setLoading(true)
+        const res = await fetch(`/api/products/${productId}`)
+        if (!res.ok) throw new Error('Failed to load product')
+        const data = await res.json()
+        setProduct(data.product)
+      } catch (err) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadProduct()
+  }, [productId])
+
+  const handleImageError = (e) => {
+    const localPath = e.target.dataset.localPath
+    if (localPath && !e.target.dataset.localTried) {
+      e.target.dataset.localTried = 'true'
+      e.target.src = localPath
+      return
+    }
+
+    if (e.target.dataset.fallbackSet === 'true') return
+
+    const width = e.target.offsetWidth || 200
+    const height = e.target.offsetHeight || 200
+
+    const svgContent =
+      `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">` +
+      `<rect width="${width}" height="${height}" fill="#f8f9fa" stroke="#dee2e6" stroke-width="2"/>` +
+      `<text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="#999" font-family="Arial, sans-serif" font-size="14">No Image</text>` +
+      `</svg>`
+
+    e.target.src = `data:image/svg+xml;base64,${btoa(svgContent)}`
+    e.target.dataset.fallbackSet = 'true'
+  }
+
+  if (loading) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center' }}>
+        <h1>Loading product...</h1>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center', color: 'red' }}>
+        <h1>Error Loading Product</h1>
+        <p>{error}</p>
+      </div>
+    )
+  }
+
+  if (!product) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center' }}>
+        <h1>Product not found</h1>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{product.product_name}</title>
+      </Head>
+      <div
+        style={{
+          fontFamily: 'Arial, sans-serif',
+          background: 'linear-gradient(135deg, #fdfdfd 0%, #c097d2 40%, #9f84ca 70%, #efc315 100%)',
+          minHeight: '100vh',
+          padding: '20px'
+        }}
+      >
+        <button onClick={() => router.back()} style={{ marginBottom: '20px' }}>← Back</button>
+        <h1 style={{ marginTop: 0 }}>{product.product_name}</h1>
+        {(() => {
+          const localPath = `/images/products/${slugify(product.product_name)}.svg`
+          return (
+            <img
+              src={product.image_url || localPath}
+              data-local-path={localPath}
+              alt={product.product_name}
+              style={{ width: '100%', maxWidth: '400px', borderRadius: '8px', marginBottom: '20px' }}
+              onError={handleImageError}
+            />
+          )
+        })()}
+        {product.description && (
+          <p style={{ maxWidth: '600px', lineHeight: 1.5 }}>{product.description}</p>
+        )}
+        <p><strong>Brand:</strong> {product.brand}</p>
+        <p><strong>Category:</strong> {product.category}</p>
+        <p><strong>Size:</strong> {product.size} {product.unit_type}</p>
+        <p><strong>SKU:</strong> {product.sku}</p>
+        {product.selling_price !== undefined && (
+          <p><strong>Selling Price:</strong> ${product.selling_price}</p>
+        )}
+        <p><strong>Cost per Unit:</strong> ${product.cost_per_unit}</p>
+        <p><strong>Current Stock:</strong> {product.current_stock}</p>
+        <p><strong>Minimum Threshold:</strong> {product.min_threshold}</p>
+        <p><strong>Location:</strong> {product.location}</p>
+      </div>
+    </>
+  )
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -1040,6 +1040,11 @@ export default function StaffPortal() {
                   <p style={{ margin: '0 0 5px 0', color: '#666' }}>
                     Cost per Unit: <strong>${selectedProduct.cost_per_unit}</strong>
                   </p>
+                  {selectedProduct.selling_price !== undefined && (
+                    <p style={{ margin: '0 0 5px 0', color: '#666' }}>
+                      Selling Price: <strong>${selectedProduct.selling_price}</strong>
+                    </p>
+                  )}
                   <p style={{ margin: '0 0 5px 0', color: '#666' }}>
                     Total Value: <strong>${(selectedProduct.current_stock * selectedProduct.cost_per_unit).toFixed(2)}</strong>
                   </p>


### PR DESCRIPTION
## Summary
- include `selling_price` in get-products endpoint
- add endpoint to fetch individual product
- show selling price in staff product modal
- add product detail page with selling price
- add migration for `selling_price` column

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853801bdb4c832a9f7b41c6f4c308cd