### PR TITLE
Add product details page

### DIFF
--- a/api/get-products.js
+++ b/api/get-products.js
@@ -23,9 +23,32 @@ export default async function handler(req, res) {
   
   try {
     console.log('🔍 Fetching products from database...');
-    
-    const { category, brand } = req.query;
-    
+
+    const { category, brand, id } = req.query;
+
+    if (id) {
+      const { data: product, error } = await supabase
+        .from('products')
+        .select('*')
+        .eq('id', id)
+        .eq('is_active', true)
+        .single();
+
+      if (error) {
+        console.error('❌ Product Fetch Error:', error);
+        return res.status(500).json({
+          error: 'Failed to fetch product',
+          details: error.message
+        });
+      }
+
+      if (!product) {
+        return res.status(404).json({ error: 'Product not found' });
+      }
+
+      return res.status(200).json({ product });
+    }
+
     let query = supabase
       .from('products')
       .select('*')

--- a/pages/all-products.js
+++ b/pages/all-products.js
@@ -129,7 +129,8 @@ export default function AllProducts() {
                 {categoryProducts.map(product => (
                   <div
                     key={product.id}
-                    style={{ background: 'white', border: '1px solid #e9ecef', borderRadius: '8px', padding: '20px', display: 'flex', gap: '15px' }}
+                    onClick={() => router.push('/products/' + product.id)}
+                    style={{ background: 'white', border: '1px solid #e9ecef', borderRadius: '8px', padding: '20px', display: 'flex', gap: '15px', cursor: 'pointer' }}
                   >
                     <div style={{ width: '80px', height: '80px', flexShrink: 0, borderRadius: '8px', overflow: 'hidden', backgroundColor: '#f8f9fa' }}>
                       <img

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -1,0 +1,119 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import Head from 'next/head'
+
+export default function ProductDetails() {
+  const router = useRouter()
+  const { id } = router.query
+
+  const [product, setProduct] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!id) return
+    const loadProduct = async () => {
+      try {
+        setLoading(true)
+        const res = await fetch(`/api/get-products?id=${id}`)
+        if (!res.ok) throw new Error('Failed to load product')
+        const data = await res.json()
+        setProduct(data.product)
+      } catch (err) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadProduct()
+  }, [id])
+
+  const handleImageError = (e) => {
+    if (e.target.dataset.fallbackSet === 'true') return
+    const width = e.target.offsetWidth || 200
+    const height = e.target.offsetHeight || 200
+    const svgContent = `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">`+
+      `<rect width="${width}" height="${height}" fill="#f8f9fa" stroke="#dee2e6" stroke-width="2"/>`+
+      `<circle cx="${width/2}" cy="${height*0.35}" r="${Math.min(width, height)*0.12}" fill="#ff9a9e" opacity="0.6"/>`+
+      `<rect x="${width*0.3}" y="${height*0.55}" width="${width*0.4}" height="${height*0.3}" rx="8" fill="#fecfef" opacity="0.6"/>`+
+      `<text x="${width/2}" y="${height*0.7}" text-anchor="middle" font-family="Arial, sans-serif" font-size="${Math.min(width, height)*0.06}" fill="#666">Product</text>`+
+      `<text x="${width/2}" y="${height*0.77}" text-anchor="middle" font-family="Arial, sans-serif" font-size="${Math.min(width, height)*0.05}" fill="#999">Image Coming Soon</text>`+
+      `</svg>`
+    e.target.src = `data:image/svg+xml;base64,${btoa(svgContent)}`
+    e.target.dataset.fallbackSet = 'true'
+  }
+
+  if (loading) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center' }}>
+        <h1>Loading product...</h1>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center', color: 'red' }}>
+        <h1>Error Loading Product</h1>
+        <p>{error}</p>
+      </div>
+    )
+  }
+
+  if (!product) {
+    return (
+      <div style={{ padding: '20px', textAlign: 'center' }}>
+        <h1>Product not found</h1>
+      </div>
+    )
+  }
+
+  const sellingPrice = product.selling_price ?? product.retail_price ?? product.price ?? null
+
+  return (
+    <>
+      <Head>
+        <title>{product.product_name}</title>
+      </Head>
+      <div
+        style={{
+          fontFamily: 'Arial, sans-serif',
+          background: 'linear-gradient(135deg, #fdfdfd 0%, #c097d2 40%, #9f84ca 70%, #efc315 100%)',
+          minHeight: '100vh',
+          padding: '20px'
+        }}
+      >
+        <button onClick={() => router.back()} style={{ marginBottom: '20px' }}>← Back</button>
+        <h1 style={{ marginTop: 0 }}>{product.product_name}</h1>
+        <div style={{ display: 'flex', gap: '20px', flexWrap: 'wrap', marginBottom: '20px' }}>
+          <div style={{ width: '200px', height: '200px', flexShrink: 0, borderRadius: '12px', overflow: 'hidden', backgroundColor: '#f8f9fa' }}>
+            <img
+              src={product.image_url || ''}
+              alt={product.product_name}
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              onError={handleImageError}
+            />
+          </div>
+          <div style={{ flex: 1 }}>
+            <p style={{ margin: '0 0 8px 0', color: '#666' }}><strong>Brand:</strong> {product.brand}</p>
+            <p style={{ margin: '0 0 8px 0', color: '#666' }}><strong>SKU:</strong> {product.sku}</p>
+            <p style={{ margin: '0 0 8px 0', color: '#666' }}><strong>Unit Size:</strong> {product.size} {product.unit_type}</p>
+            <p style={{ margin: '0 0 8px 0', color: '#666' }}><strong>Cost per Unit:</strong> ${product.cost_per_unit}</p>
+            {sellingPrice && (
+              <p style={{ margin: '0 0 8px 0', color: '#666' }}><strong>Selling Price:</strong> ${sellingPrice}</p>
+            )}
+            <p style={{ margin: '0 0 8px 0', color: '#666' }}><strong>Current Stock:</strong> {product.current_stock}</p>
+            <p style={{ margin: '0 0 8px 0', color: '#666' }}><strong>Minimum Threshold:</strong> {product.min_threshold}</p>
+            <p style={{ margin: '0 0 8px 0', color: '#666' }}><strong>Location:</strong> {product.location}</p>
+          </div>
+        </div>
+        {product.description && (
+          <div style={{ background: 'white', padding: '20px', borderRadius: '8px', maxWidth: '600px' }}>
+            <h3>Description</h3>
+            <p style={{ margin: 0, lineHeight: '1.5' }}>{product.description}</p>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -1058,11 +1058,25 @@ export default function StaffPortal() {
                 </div>
               )}
 
-              <div style={{ 
-                display: 'flex', 
-                gap: '10px', 
-                justifyContent: 'flex-end' 
+              <div style={{
+                display: 'flex',
+                gap: '10px',
+                justifyContent: 'flex-end'
               }}>
+                <button
+                  onClick={() => router.push('/products/' + selectedProduct.id)}
+                  style={{
+                    background: '#ff9a9e',
+                    color: 'white',
+                    border: 'none',
+                    padding: '10px 20px',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontSize: '14px'
+                  }}
+                >
+                  View Full Page
+                </button>
                 <button
                   onClick={closeProductDetails}
                   style={{


### PR DESCRIPTION
## Summary
- add single product fetch capability to `get-products` API
- create `/products/[id].js` details page
- make product cards link to product page
- link to product page from dashboard modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68538019da54832ab24d1083dfef2718