### PR TITLE
Add Jest setup with Supabase client test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "deploy": "vercel --prod",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "dependencies": {
     "next": "^14.0.0",
@@ -22,7 +22,8 @@
   },
   "devDependencies": {
     "eslint": "^8.0.0",
-    "eslint-config-next": "^14.0.0"
+    "eslint-config-next": "^14.0.0",
+    "jest": "^29.7.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/tests/supabaseClient.test.js
+++ b/tests/supabaseClient.test.js
@@ -1,0 +1,12 @@
+const { createSupabaseClient } = require('../utils/supabaseClient');
+
+describe('Supabase client initialization', () => {
+  it('initializes when environment variables are set', () => {
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+
+    const client = createSupabaseClient();
+    expect(client).toBeDefined();
+    expect(typeof client).toBe('object');
+  });
+});

--- a/utils/supabaseClient.js
+++ b/utils/supabaseClient.js
@@ -1,0 +1,10 @@
+const { createClient } = require('@supabase/supabase-js');
+
+function createSupabaseClient() {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  }
+  return createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+}
+
+module.exports = { createSupabaseClient };


### PR DESCRIPTION
## Summary
- configure Jest for testing
- add a simple Supabase client module
- test Supabase client initializes when env vars are present
- wire `npm test` to run Jest

## Testing
- `npm test` *(fails: jest not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68578cccfef0832aaa0cc1486189587a