### PR TITLE
Add auth middleware tests

### DIFF
--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,43 @@
+const requireAuth = require('../utils/requireAuth');
+
+jest.mock('@supabase/supabase-js', () => {
+  return {
+    createClient: jest.fn(() => ({
+      auth: {
+        getUser: jest.fn((token) => {
+          if (token === 'valid-token') {
+            return Promise.resolve({ data: { user: { id: '123' } }, error: null });
+          }
+          return Promise.resolve({ data: null, error: new Error('Invalid token') });
+        })
+      }
+    }))
+  };
+});
+
+describe('requireAuth', () => {
+  beforeEach(() => {
+    process.env.SUPABASE_URL = 'http://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+  });
+
+  it('sends 401 when Authorization header is missing', async () => {
+    const req = { headers: {} };
+    const res = { statusCode: 0, end: jest.fn() };
+
+    await requireAuth(req, res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.end).toHaveBeenCalledWith('Unauthorized');
+  });
+
+  it('allows request with valid token', async () => {
+    const req = { headers: { authorization: 'Bearer valid-token' } };
+    const res = { statusCode: 0, end: jest.fn() };
+
+    await requireAuth(req, res);
+
+    expect(res.end).not.toHaveBeenCalled();
+    expect(req.user).toEqual({ id: '123' });
+  });
+});

--- a/utils/requireAuth.js
+++ b/utils/requireAuth.js
@@ -1,0 +1,34 @@
+const { createClient } = require('@supabase/supabase-js');
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabase = supabaseUrl && supabaseKey ? createClient(supabaseUrl, supabaseKey) : null;
+
+async function requireAuth(req, res) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    res.statusCode = 401;
+    res.end('Unauthorized');
+    return null;
+  }
+  const tokenMatch = authHeader.match(/^Bearer\s+(.*)$/);
+  if (!tokenMatch) {
+    res.statusCode = 401;
+    res.end('Unauthorized');
+    return null;
+  }
+  const token = tokenMatch[1];
+  if (!supabase) {
+    throw new Error('Supabase client not configured');
+  }
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data?.user) {
+    res.statusCode = 401;
+    res.end('Unauthorized');
+    return null;
+  }
+  req.user = data.user;
+  return data.user;
+}
+
+module.exports = requireAuth;


### PR DESCRIPTION
## Summary
- add a `requireAuth` helper for API routes
- test auth logic with mocked Supabase client

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ba974980832a8da8a33f96a02270