### PR TITLE
Centralize API CORS headers

### DIFF
--- a/api/booking-created-enhanced.js
+++ b/api/booking-created-enhanced.js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -13,9 +14,7 @@ export default async function handler(req, res) {
   console.log('Body type:', typeof req.body)
   console.log('Body content:', JSON.stringify(req.body, null, 2))
   
-  // CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  setCorsHeaders(res, 'POST')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, x-wix-webhook-signature')
   
   if (req.method === 'OPTIONS') {

--- a/api/booking-created.js
+++ b/api/booking-created.js
@@ -1,5 +1,6 @@
 // api/booking-created.js - COMPLETE CORRECTED VERSION
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
  process.env.SUPABASE_URL,
@@ -7,10 +8,8 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
- // Add CORS headers
- res.setHeader('Access-Control-Allow-Origin', '*');
- res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
- res.setHeader('Access-Control-Allow-Headers', 'Content-Type, x-wix-webhook-signature');
+  setCorsHeaders(res, 'POST');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, x-wix-webhook-signature');
  
  if (req.method === 'OPTIONS') {
    res.status(200).end();

--- a/api/complete-usage-session.js
+++ b/api/complete-usage-session.js
@@ -1,6 +1,7 @@
 // api/complete-usage-session.js
 // Mark a product usage session as completed or create it if it doesn't exist
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -8,10 +9,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  // Add CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  setCorsHeaders(res, 'POST');
   
   if (req.method === 'OPTIONS') {
     res.status(200).end();

--- a/api/fix-get-branding.js
+++ b/api/fix-get-branding.js
@@ -1,5 +1,6 @@
 // api/fix-get-branding.js - Fixed version that handles multiple records
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,10 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  // Add CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+  setCorsHeaders(res, 'GET')
 
   if (req.method === 'OPTIONS') {
     res.status(200).end()

--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -1,5 +1,6 @@
 // api/get-appointments.js
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,9 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  setCorsHeaders(res, 'GET');
   
   if (req.method === 'OPTIONS') {
     res.status(200).end();

--- a/api/get-booking/[bookingId].js
+++ b/api/get-booking/[bookingId].js
@@ -1,5 +1,6 @@
 // api/get-booking/[bookingId].js
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,9 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  setCorsHeaders(res, 'GET');
   
   if (req.method === 'OPTIONS') {
     res.status(200).end();

--- a/api/get-branding.js
+++ b/api/get-branding.js
@@ -1,5 +1,6 @@
 // api/get-branding.js - UPDATED VERSION (replace your existing file)
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,10 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  // Add CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+  setCorsHeaders(res, 'GET')
 
   if (req.method === 'OPTIONS') {
     res.status(200).end()

--- a/api/get-inventory-alerts.js
+++ b/api/get-inventory-alerts.js
@@ -1,5 +1,6 @@
 // api/get-inventory-alerts.js - Simplified for your current schema
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,10 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  // Add CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  setCorsHeaders(res, 'GET');
   
   if (req.method === 'OPTIONS') {
     res.status(200).end();

--- a/api/get-products.js
+++ b/api/get-products.js
@@ -1,5 +1,6 @@
 // api/get-products.js - Corrected for your schema
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,10 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  // Add CORS headers for cross-origin requests
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  setCorsHeaders(res, 'GET')
   
   if (req.method === 'OPTIONS') {
     res.status(200).end();

--- a/api/get-service/[serviceId].js
+++ b/api/get-service/[serviceId].js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -6,9 +7,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+  setCorsHeaders(res, 'GET')
 
   if (req.method === 'OPTIONS') {
     res.status(200).end()

--- a/api/payment-approved.js
+++ b/api/payment-approved.js
@@ -1,5 +1,6 @@
 // api/payment-approved.js - New webhook for Wix payment processing
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,9 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  // Add CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  setCorsHeaders(res, 'POST');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, x-wix-webhook-signature');
   
   if (req.method === 'OPTIONS') {

--- a/api/product-usage-stats.js
+++ b/api/product-usage-stats.js
@@ -1,5 +1,6 @@
 // api/product-usage-stats.js
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,9 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  setCorsHeaders(res, 'GET');
   
   if (req.method === 'OPTIONS') {
     res.status(200).end();

--- a/api/products/[id].js
+++ b/api/products/[id].js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -6,9 +7,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+  setCorsHeaders(res, 'GET')
 
   if (req.method === 'OPTIONS') {
     res.status(200).end()

--- a/api/services.js
+++ b/api/services.js
@@ -1,5 +1,6 @@
 // api/services.js - Get salon services
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,10 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  // Add CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  setCorsHeaders(res, 'GET');
   
   if (req.method === 'OPTIONS') {
     res.status(200).end();

--- a/api/services/[id].js
+++ b/api/services/[id].js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -6,9 +7,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+  setCorsHeaders(res, 'GET')
 
   if (req.method === 'OPTIONS') {
     res.status(200).end()

--- a/api/test-env.js
+++ b/api/test-env.js
@@ -1,7 +1,8 @@
 // Create this file: api/test-env.js
+import { setCorsHeaders } from '../utils/cors'
+
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  setCorsHeaders(res, 'GET')
   
   if (req.method === 'OPTIONS') {
     return res.status(200).end()

--- a/api/update-appointment-notes.js
+++ b/api/update-appointment-notes.js
@@ -1,5 +1,6 @@
 // api/update-appointment-notes.js - Save appointment notes
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,10 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  // Add CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  setCorsHeaders(res, 'POST');
   
   if (req.method === 'OPTIONS') {
     res.status(200).end();

--- a/api/update-product-image.js
+++ b/api/update-product-image.js
@@ -1,5 +1,6 @@
 // api/update-product-image.js - Update product images
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,10 +8,7 @@ const supabase = createClient(
 )
 
 export default async function handler(req, res) {
-  // Add CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, PUT, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  setCorsHeaders(res, 'POST, PUT');
 
   if (req.method === 'OPTIONS') {
     res.status(200).end();

--- a/api/upload-product-image.js
+++ b/api/upload-product-image.js
@@ -3,6 +3,7 @@ import formidable from 'formidable'
 import fs from 'fs'
 import path from 'path'
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -17,9 +18,7 @@ export const config = {
 }
 
 export default async function handler(req, res) {
-  // Add comprehensive CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  setCorsHeaders(res, 'POST')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   
   if (req.method === 'OPTIONS') {

--- a/api/upload-salon-logo.js
+++ b/api/upload-salon-logo.js
@@ -4,6 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -17,9 +18,7 @@ export const config = {
 }
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  setCorsHeaders(res, 'POST')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   
   if (req.method === 'OPTIONS') {

--- a/api/webhook-router.js
+++ b/api/webhook-router.js
@@ -1,6 +1,7 @@
 // api/webhook-router.js - FINAL VERSION with fixed labels and upserts
 import jwt from 'jsonwebtoken';
 import { createClient } from '@supabase/supabase-js';
+import { setCorsHeaders } from '../utils/cors';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -54,8 +55,7 @@ export default async function handler(req, res) {
   console.log('Body preview:', JSON.stringify(req.body).substring(0, 500));
   
   // Set CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  setCorsHeaders(res, 'POST');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, x-wix-webhook-signature');
   
   if (req.method === 'OPTIONS') {

--- a/utils/cors.js
+++ b/utils/cors.js
@@ -1,0 +1,7 @@
+export function setCorsHeaders(res, methods) {
+  const methodList = Array.isArray(methods) ? methods.join(', ') : methods
+  const allowMethods = methodList.includes('OPTIONS') ? methodList : `${methodList}, OPTIONS`
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', allowMethods)
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+}


### PR DESCRIPTION
## Summary
- add `setCorsHeaders` helper
- refactor API routes to use the helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858bdbd048c832aa0ce7ecb0001a731