### PR TITLE
Fix total price display

### DIFF
--- a/pages/staff.js
+++ b/pages/staff.js
@@ -1224,7 +1224,17 @@ export default function StaffPortal() {
                   </div>
                   <div>
                     <strong>Total Price:</strong><br />
-                    ${selectedAppointment.total_price ? parseFloat(selectedAppointment.total_price).toFixed(2) : '0.00'}
+                    {
+                      (() => {
+                        const priceSource =
+                          selectedAppointment.total_price !== undefined && selectedAppointment.total_price !== null
+                            ? selectedAppointment.total_price
+                            : selectedAppointment.salon_services?.price;
+                        return priceSource !== undefined && priceSource !== null
+                          ? `$${parseFloat(priceSource).toFixed(2)}`
+                          : '$0.00';
+                      })()
+                    }
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- update appointment detail modal to fall back on service price

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f753dd70832a8ecfe474378265f0