### PR TITLE
Add navigation links for orders and customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ After signing in you can open these screens directly:
 - **/customers** – browse and search customer records.
 
 Navigate by entering the URL in your browser or by linking from the staff portal.
+The staff portal now includes dedicated **Orders** and **Customers** buttons for quick access.
 
 ## Testing
 

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 
 export default function OrdersPage() {
+  const router = useRouter()
   const [orders, setOrders] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -42,7 +44,22 @@ export default function OrdersPage() {
         <title>Orders - Keeping It Cute Salon</title>
       </Head>
       <div style={{ fontFamily: 'Arial, sans-serif', padding: '20px', backgroundColor: '#f8f9fa', minHeight: '100vh' }}>
-        <h1 style={{ marginTop: 0, marginBottom: '20px', textAlign: 'center' }}>🛒 Recent Orders</h1>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
+          <h1 style={{ margin: 0 }}>🛒 Recent Orders</h1>
+          <button
+            onClick={() => router.push('/staff')}
+            style={{
+              background: 'linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%)',
+              color: 'white',
+              border: 'none',
+              padding: '10px 20px',
+              borderRadius: '6px',
+              cursor: 'pointer'
+            }}
+          >
+            ← Back to Staff
+          </button>
+        </div>
         {loading ? (
           <p style={{ textAlign: 'center' }}>Loading orders...</p>
         ) : error ? (

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -422,6 +422,42 @@ export default function StaffPortal() {
                   📋 All Products
                 </button>
               )}
+
+              {/* Orders Button - Show on all tabs */}
+              <button
+                onClick={() => router.push('/orders')}
+                style={{
+                  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                  color: 'white',
+                  border: 'none',
+                  padding: '12px 20px',
+                  borderRadius: '6px',
+                  cursor: 'pointer',
+                  fontSize: '14px',
+                  fontWeight: 'bold',
+                  boxShadow: '0 2px 4px rgba(0,0,0,0.2)'
+                }}
+              >
+                🛒 View Orders
+              </button>
+
+              {/* Customers Button - Show on all tabs */}
+              <button
+                onClick={() => router.push('/customers')}
+                style={{
+                  background: 'linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%)',
+                  color: 'white',
+                  border: 'none',
+                  padding: '12px 20px',
+                  borderRadius: '6px',
+                  cursor: 'pointer',
+                  fontSize: '14px',
+                  fontWeight: 'bold',
+                  boxShadow: '0 2px 4px rgba(0,0,0,0.2)'
+                }}
+              >
+                👥 View Customers
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add links to Orders and Customers on staff page
- add a back button on the Orders page
- update README notes on new links

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0142fec4832ab6b4f72709ae3196