### PR TITLE
Fix translation objects in orders and customers pages

### DIFF
--- a/pages/customers.js
+++ b/pages/customers.js
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
+import { toPlainString } from '../utils/translation'
 
 export default function CustomersPage() {
   const router = useRouter()
@@ -40,7 +41,24 @@ export default function CustomersPage() {
       const res = await fetch(`/api/get-customers?limit=100&sort_by=${sort_by}&sort_order=${sort_order}`)
       if (!res.ok) throw new Error('Failed to load customers')
       const data = await res.json()
-      setCustomers(data.customers || [])
+      const normalized = (data.customers || []).map(c => ({
+        ...c,
+        first_name: toPlainString(c.first_name),
+        last_name: toPlainString(c.last_name),
+        email: toPlainString(c.email),
+        phone: toPlainString(c.phone),
+        address: c.address && typeof c.address === 'object'
+          ? {
+              ...c.address,
+              addressLine1: toPlainString(c.address.addressLine1),
+              city: toPlainString(c.address.city),
+              region: toPlainString(c.address.region),
+              postalCode: toPlainString(c.address.postalCode),
+              country: toPlainString(c.address.country)
+            }
+          : c.address
+      }))
+      setCustomers(normalized)
     } catch (err) {
       setError(err.message)
     } finally {

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
+import { toPlainString } from '../utils/translation'
 
 export default function OrdersPage() {
   const router = useRouter()
@@ -20,7 +21,15 @@ export default function OrdersPage() {
       const res = await fetch('/api/get-orders')
       if (!res.ok) throw new Error('Failed to load orders')
       const data = await res.json()
-      setOrders(data.orders || [])
+      const normalized = (data.orders || []).map(order => ({
+        ...order,
+        order_number: toPlainString(order.order_number),
+        customer_email: toPlainString(order.customer_email),
+        fulfillment_status: toPlainString(order.fulfillment_status),
+        payment_status: toPlainString(order.payment_status),
+        total_amount: toPlainString(order.total_amount)
+      }))
+      setOrders(normalized)
     } catch (err) {
       setError(err.message)
     } finally {

--- a/utils/translation.js
+++ b/utils/translation.js
@@ -1,0 +1,12 @@
+export function toPlainString(value) {
+  if (value && typeof value === 'object') {
+    if (typeof value.value === 'string') return value.value;
+    if (typeof value.text === 'string') return value.text;
+    if (typeof value.formatted === 'string') return value.formatted;
+    // fall back to first string property if any
+    const prop = Object.values(value).find(v => typeof v === 'string');
+    if (prop) return prop;
+    return '';
+  }
+  return value == null ? '' : value;
+}


### PR DESCRIPTION
## Summary
- add a helper to extract strings from translation objects
- normalize orders using the helper
- normalize customers using the helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a05eeab80832ab0241cd4a366d1d3