### PR TITLE
Add global error boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ psql $SUPABASE_URL < migrations/20240102_add_profiles_table.sql
 Use the `/login` and `/signup` pages to authenticate.
 After login, requests include a `Bearer` token from the Supabase session in the `Authorization` header.
 
+### Error handling
+
+Unexpected client errors are captured by a React error boundary defined in `pages/_app.js`. When an exception occurs, the boundary renders a simple message instead of leaving the page blank.
+
+
 ## 🖥️ Pages
 
 After signing in you can open these screens directly:

--- a/components/ErrorBoundary.js
+++ b/components/ErrorBoundary.js
@@ -1,0 +1,31 @@
+import React from 'react'
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: '2rem', textAlign: 'center' }}>
+          <h2>Something went wrong.</h2>
+          {this.state.error && (
+            <pre style={{ color: 'red' }}>{this.state.error.message}</pre>
+          )}
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import ErrorBoundary from '../components/ErrorBoundary'
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <ErrorBoundary>
+      <Component {...pageProps} />
+    </ErrorBoundary>
+  )
+}


### PR DESCRIPTION
## Summary
- provide an `ErrorBoundary` component to catch React rendering errors
- wrap pages with the error boundary in `pages/_app.js`
- document the error boundary in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5b916534832ab20df284c4d24301