### PR TITLE
Fix booking update webhook

### DIFF
--- a/api/booking-updated.js
+++ b/api/booking-updated.js
@@ -11,8 +11,22 @@ export default async function handler(req, res) {
   }
 
   try {
-    const bookingData = req.body;
-    console.log('🔄 Booking Updated:', JSON.stringify(bookingData, null, 2));
+    const rawBody = req.body
+    console.log('🔄 Booking Updated Raw:', JSON.stringify(rawBody, null, 2))
+
+    // Handle both direct booking objects and Wix webhook envelopes
+    let bookingData = rawBody
+    if (rawBody?.updatedEvent) {
+      bookingData =
+        rawBody.updatedEvent.currentEntity ||
+        (typeof rawBody.updatedEvent.currentEntityAsJson === 'string'
+          ? JSON.parse(rawBody.updatedEvent.currentEntityAsJson)
+          : rawBody.updatedEvent.currentEntityAsJson) ||
+        rawBody.updatedEvent.entity ||
+        rawBody
+    }
+
+    console.log('🔄 Parsed Booking Data:', JSON.stringify(bookingData, null, 2))
 
     const updateData = {
       customer_email: bookingData.contactDetails?.email || bookingData.formInfo?.email,
@@ -21,12 +35,16 @@ export default async function handler(req, res) {
       service_name: bookingData.service?.name || bookingData.serviceInfo?.name,
       service_duration: bookingData.service?.duration || bookingData.serviceInfo?.duration,
       appointment_date: bookingData.startDate || bookingData.start?.timestamp,
+      end_time: bookingData.endDate || bookingData.end?.timestamp,
       total_price: bookingData.totalPrice || bookingData.payment?.finalPrice,
       staff_member: bookingData.staffMember?.name || bookingData.resource?.name,
       notes: bookingData.additionalFields?.notes || bookingData.formInfo?.additionalFields,
-      status: bookingData.status || 'updated',
+      status: bookingData.status,
+      payment_status: bookingData.paymentStatus?.toLowerCase(),
+      revision: parseInt(bookingData.revision) || undefined,
       payload: bookingData,
-      updated_at: new Date().toISOString()
+      updated_at: new Date().toISOString(),
+      updated_date: bookingData.updatedDate
     };
 
     // Remove undefined values
@@ -38,11 +56,26 @@ export default async function handler(req, res) {
       .from('bookings')
       .update(updateData)
       .eq('wix_booking_id', bookingData.id || bookingData.bookingId)
-      .select();
+      .select()
+      .single();
 
     if (error) {
       console.error('❌ Booking Update Error:', error);
       return res.status(500).json({ error: 'Failed to update booking', details: error.message });
+    }
+
+    // Update related usage session if it exists
+    try {
+      await supabase
+        .from('product_usage_sessions')
+        .update({
+          customer_email: updateData.customer_email,
+          customer_name: updateData.customer_name,
+          service_performed: updateData.service_name
+        })
+        .eq('booking_id', bookingData.id || bookingData.bookingId);
+    } catch (usageError) {
+      console.error('⚠️ Product usage session update failed:', usageError.message);
     }
 
     console.log('✅ Booking Updated Successfully:', data);

--- a/tests/booking-updated.test.js
+++ b/tests/booking-updated.test.js
@@ -1,0 +1,57 @@
+// tests for api/booking-updated.js
+const createUpdateQuery = (result) => {
+  const promise = Promise.resolve(result);
+  promise.update = jest.fn(() => promise);
+  promise.eq = jest.fn(() => promise);
+  promise.select = jest.fn(() => promise);
+  promise.single = jest.fn(() => promise);
+  return promise;
+};
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this; }),
+  json: jest.fn(function(){ return this; })
+});
+
+describe('booking-updated handler', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.SUPABASE_URL = 'http://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+  });
+
+  test('parses webhook envelope and updates booking', async () => {
+    const bookingQuery = createUpdateQuery({ data: { id: '1' }, error: null });
+    const usageQuery = createUpdateQuery({ data: {}, error: null });
+    const from = jest.fn((table) => {
+      if (table === 'bookings') return bookingQuery;
+      if (table === 'product_usage_sessions') return usageQuery;
+      return createUpdateQuery({});
+    });
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+
+    const { default: handler } = await import('../api/booking-updated.js');
+
+    const req = {
+      method: 'POST',
+      body: {
+        updatedEvent: {
+          currentEntity: {
+            id: '1',
+            contactDetails: { email: 'john@example.com', firstName: 'John', lastName: 'Doe' },
+            paymentStatus: 'PAID',
+            status: 'CONFIRMED'
+          }
+        }
+      }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(from).toHaveBeenCalledWith('bookings');
+    expect(bookingQuery.update).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'Booking updated successfully' }));
+  });
+});


### PR DESCRIPTION
## Summary
- handle Wix webhook envelopes in the booking update API
- store additional fields and update usage sessions
- test booking update handler

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de743a41c832a8d55dd5ca6c406ce