### PR TITLE
Add appointment cancellation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET=salon-images
 
 # Optional: Webhook Security
 WIX_WEBHOOK_SECRET=your-wix-webhook-secret-for-verification
+WIX_API_TOKEN=your-wix-api-token
 
 # Optional: Email Notifications
 NOTIFICATION_EMAIL=your-email@keepingitcute.com

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 - `POST /api/booking-created` - New appointments
 - `POST /api/booking-updated` - Appointment changes
 - `POST /api/booking-canceled` - Cancellations
+- `POST /api/cancel-booking/[bookingId]` - Cancel a booking via Wix API
 
 ### Customer Webhooks
 - `POST /api/contact-created` - New customer registrations
@@ -147,6 +148,7 @@ Copy `.env.example` to `.env.local` and fill in your Supabase credentials:
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 - `SUPABASE_STORAGE_BUCKET` (e.g., `salon-images`)
 - `NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET` (same as above for the browser)
+- `WIX_API_TOKEN` Wix API token used for booking operations
 
 These values are required to build and run the API routes. Variables prefixed
 with `NEXT_PUBLIC_` are exposed to the browser, while server-side handlers rely

--- a/api/cancel-booking/[bookingId].js
+++ b/api/cancel-booking/[bookingId].js
@@ -1,0 +1,58 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { bookingId } = req.query
+  const { revision, notifyParticipants = false, message, flowControlSettings = {} } = req.body || {}
+
+  if (!bookingId || !revision) {
+    return res.status(400).json({ error: 'bookingId and revision are required' })
+  }
+
+  try {
+    // Call Wix API to cancel booking
+    const wixRes = await fetch(
+      `https://www.wixapis.com/_api/bookings-service/v2/bookings/${bookingId}/cancel`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify({
+          participantNotification: { notifyParticipants, message },
+          revision: String(revision),
+          flowControlSettings
+        })
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res.status(wixRes.status).json({ error: 'Failed to cancel booking', details: wixData })
+    }
+
+    // Update local database
+    await supabase
+      .from('bookings')
+      .update({
+        status: 'canceled',
+        cancelled_date: new Date().toISOString(),
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', bookingId)
+
+    res.status(200).json({ success: true, booking: wixData.booking })
+  } catch (err) {
+    console.error('Cancel booking error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -161,6 +161,34 @@ export default function StaffPortal() {
     }
   }
 
+  const cancelAppointment = async (appointment) => {
+    if (!appointment) return
+    if (!confirm('Cancel this appointment?')) return
+
+    try {
+      const response = await fetch(`/api/cancel-booking/${appointment.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ revision: appointment.revision })
+      })
+
+      if (!response.ok) throw new Error('Cancel failed')
+
+      setAppointments(appointments.map(a =>
+        a.id === appointment.id ? { ...a, status: 'canceled' } : a
+      ))
+
+      if (selectedAppointment?.id === appointment.id) {
+        setSelectedAppointment({ ...selectedAppointment, status: 'canceled' })
+      }
+
+      alert('Appointment canceled')
+    } catch (error) {
+      console.error('Error canceling appointment:', error)
+      alert('Failed to cancel appointment')
+    }
+  }
+
   const navigateToAudit = () => {
     router.push('/inventory-audit')
   }
@@ -695,7 +723,7 @@ export default function StaffPortal() {
                         </div>
 
                         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '8px' }}>
-                          <span style={{ 
+                          <span style={{
                             padding: '6px 12px',
                             borderRadius: '20px',
                             fontSize: '0.8em',
@@ -707,13 +735,32 @@ export default function StaffPortal() {
                           </span>
 
                           {appointment.total_price && (
-                            <span style={{ 
+                            <span style={{
                               fontSize: '1.1em',
                               fontWeight: 'bold',
                               color: '#333'
                             }}>
                               ${parseFloat(appointment.total_price).toFixed(2)}
                             </span>
+                          )}
+
+                          {appointment.status !== 'canceled' && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                cancelAppointment(appointment)
+                              }}
+                              style={{
+                                background: 'none',
+                                border: 'none',
+                                color: '#d32f2f',
+                                fontSize: '16px',
+                                cursor: 'pointer'
+                              }}
+                              title="Cancel appointment"
+                            >
+                              ×
+                            </button>
                           )}
                         </div>
                       </div>
@@ -1430,11 +1477,27 @@ export default function StaffPortal() {
               </div>
 
               {/* Action Buttons */}
-              <div style={{ 
-                display: 'flex', 
-                gap: '15px', 
-                justifyContent: 'flex-end' 
+              <div style={{
+                display: 'flex',
+                gap: '15px',
+                justifyContent: 'flex-end'
               }}>
+                {selectedAppointment?.status !== 'canceled' && (
+                  <button
+                    onClick={() => cancelAppointment(selectedAppointment)}
+                    style={{
+                      background: '#d32f2f',
+                      color: 'white',
+                      border: 'none',
+                      padding: '12px 20px',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      fontSize: '14px'
+                    }}
+                  >
+                    Cancel Appointment
+                  </button>
+                )}
                 <button
                   onClick={closeAppointmentDetails}
                   style={{


### PR DESCRIPTION
## Summary
- implement API to cancel Wix bookings and update local DB
- expose `WIX_API_TOKEN` in example env file
- document new API endpoint and token usage
- add cancel button on appointment details with ability to cancel
- allow quick cancellation from appointment list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df6105840832a83e949bf6fbafcfe