### PR TITLE
Implement query-based tab switching

### DIFF
--- a/pages/staff.js
+++ b/pages/staff.js
@@ -28,6 +28,13 @@ export default function StaffPortal() {
   const [appointmentSearch, setAppointmentSearch] = useState('')
   const [appointmentSort, setAppointmentSort] = useState('newest')
 
+  // Sync active tab with query string
+  useEffect(() => {
+    if (router.query.tab && typeof router.query.tab === 'string') {
+      setActiveTab(router.query.tab)
+    }
+  }, [router.query.tab])
+
   useEffect(() => {
     loadData()
   }, [])
@@ -411,7 +418,10 @@ export default function StaffPortal() {
             {['inventory', 'services', 'appointments', 'alerts'].map(tab => (
               <button
                 key={tab}
-                onClick={() => setActiveTab(tab)}
+                onClick={() => {
+                  router.push({ pathname: '/staff', query: { tab } }, undefined, { shallow: true })
+                  setActiveTab(tab)
+                }}
                 style={{
                   padding: '15px 25px',
                   border: 'none',


### PR DESCRIPTION
## Summary
- push staff tab selection to the query string
- read `tab` query parameter on page load to set active tab

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e1718fa6c832a8e13ec3c6aeb3457