### PR TITLE
Add query availability API test

### DIFF
--- a/api/query-availability.js
+++ b/api/query-availability.js
@@ -1,0 +1,41 @@
+import { setCorsHeaders } from '../utils/cors'
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'POST')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { query } = req.body || {}
+  const serviceId = query?.filter?.serviceId
+
+  if (!serviceId) {
+    return res.status(400).json({ error: 'serviceId is required' })
+  }
+
+  try {
+    const wixRes = await fetch(
+      'https://www.wixapis.com/_api/bookings-service/v2/availability/query',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN,
+        },
+        body: JSON.stringify(req.body),
+      }
+    )
+
+    const data = await wixRes.json()
+    res.status(wixRes.status).json(data)
+  } catch (err) {
+    console.error('Query availability error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/tests/query-availability.test.js
+++ b/tests/query-availability.test.js
@@ -1,0 +1,70 @@
+// tests for api/query-availability.js
+
+const createRes = () => ({
+  status: jest.fn(function () { return this }),
+  json: jest.fn(function () { return this }),
+  end: jest.fn(function () { return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  global.fetch = jest.fn()
+})
+
+afterEach(() => {
+  delete global.fetch
+})
+
+describe('query-availability handler', () => {
+  test('returns 405 on non-POST requests', async () => {
+    const { default: handler } = await import('../api/query-availability.js')
+
+    const req = { method: 'GET', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('validates serviceId in request body', async () => {
+    const { default: handler } = await import('../api/query-availability.js')
+
+    const req = { method: 'POST', body: { query: { filter: {} } } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('serviceId') })
+    )
+  })
+
+  test('proxies wix response for valid data', async () => {
+    global.fetch.mockResolvedValue({
+      status: 200,
+      json: jest.fn().mockResolvedValue({ ok: true })
+    })
+
+    const { default: handler } = await import('../api/query-availability.js')
+
+    const reqBody = { query: { filter: { serviceId: '123' } } }
+    const req = { method: 'POST', body: reqBody }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://www.wixapis.com/_api/bookings-service/v2/availability/query',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(reqBody)
+      })
+    )
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({ ok: true })
+  })
+})


### PR DESCRIPTION
## Summary
- implement query-availability API handler
- add Jest tests that mock Wix API responses

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e19c3dd1c832ab60a354e20b1f81c