### PR TITLE
Replace inline back buttons with shared StaffNavBar

### DIFF
--- a/components/StaffNavBar.js
+++ b/components/StaffNavBar.js
@@ -1,0 +1,36 @@
+import { useRouter } from 'next/router'
+
+export default function StaffNavBar({ branding, activeTab }) {
+  const router = useRouter()
+  const tabs = ['inventory', 'services', 'appointments', 'alerts']
+
+  const handleTabClick = (tab) => {
+    router.push({ pathname: '/staff', query: { tab } })
+  }
+
+  return (
+    <div style={{ backgroundColor: 'white', borderBottom: '1px solid #e9ecef', padding: '0 20px' }}>
+      <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
+        {tabs.map((tab) => (
+          <button
+            key={tab}
+            onClick={() => handleTabClick(tab)}
+            style={{
+              padding: '15px 25px',
+              border: 'none',
+              backgroundColor: activeTab === tab ? (branding?.primary_color || '#ff9a9e') : 'transparent',
+              color: activeTab === tab ? 'white' : '#666',
+              cursor: 'pointer',
+              fontSize: '16px',
+              fontWeight: activeTab === tab ? 'bold' : 'normal',
+              borderBottom: activeTab === tab ? `3px solid ${branding?.primary_color || '#ff9a9e'}` : 'none',
+              textTransform: 'capitalize'
+            }}
+          >
+            {tab === 'inventory' && '📦'} {tab === 'services' && '✨'} {tab === 'appointments' && '📅'} {tab === 'alerts' && '🚨'} {tab}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/pages/inventory-audit.js
+++ b/pages/inventory-audit.js
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
+import StaffNavBar from '../components/StaffNavBar'
 
 export default function InventoryAudit() {
   const router = useRouter()
@@ -14,9 +15,11 @@ export default function InventoryAudit() {
   const [searchTerm, setSearchTerm] = useState('')
   const [selectedCategory, setSelectedCategory] = useState('all')
   const [staffName, setStaffName] = useState('')
+  const [branding, setBranding] = useState(null)
 
   useEffect(() => {
     loadProducts()
+    loadBranding()
   }, [])
 
   const loadProducts = async () => {
@@ -43,6 +46,18 @@ export default function InventoryAudit() {
       setError(err.message)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const loadBranding = async () => {
+    try {
+      const res = await fetch('/api/get-branding')
+      if (res.ok) {
+        const data = await res.json()
+        setBranding(data.branding)
+      }
+    } catch (err) {
+      console.error('Error loading branding:', err)
     }
   }
 
@@ -222,22 +237,11 @@ export default function InventoryAudit() {
                 Complete physical count of all salon inventory
               </p>
             </div>
-            <button
-              onClick={() => router.back()}
-              style={{
-                background: 'rgba(255,255,255,0.2)',
-                color: 'white',
-                border: '1px solid rgba(255,255,255,0.3)',
-                padding: '8px 16px',
-                borderRadius: '6px',
-                cursor: 'pointer',
-                fontSize: '14px'
-              }}
-            >
-              ← Back to Inventory
-            </button>
+            <div></div>
           </div>
         </div>
+
+        <StaffNavBar branding={branding} activeTab="inventory" />
 
         {/* Staff Information */}
         <div style={{ 

--- a/pages/logo-management.js
+++ b/pages/logo-management.js
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
+import StaffNavBar from '../components/StaffNavBar'
 
 const BASE_STORAGE_URL = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${process.env.NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET}`
 const DEFAULT_LOGO = `${BASE_STORAGE_URL}/logo/salon-logo.png`
@@ -190,22 +191,11 @@ export default function LogoManagement() {
                 Upload and manage your salon's branding
               </p>
             </div>
-            <button
-              onClick={() => router.push('/staff')}
-              style={{
-                background: 'rgba(255,255,255,0.2)',
-                color: 'white',
-                border: '1px solid rgba(255,255,255,0.3)',
-                padding: '10px 20px',
-                borderRadius: '6px',
-                cursor: 'pointer',
-                fontSize: '14px'
-              }}
-            >
-              ← Back to Staff Portal
-            </button>
+            <div></div>
           </div>
         </div>
+
+        <StaffNavBar branding={branding} activeTab="inventory" />
 
         <div style={{ maxWidth: '800px', margin: '0 auto' }}>
           {/* Error Display */}

--- a/pages/product-usage/[bookingId].js
+++ b/pages/product-usage/[bookingId].js
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
+import StaffNavBar from '../../components/StaffNavBar'
 
 export default function ProductUsageForm() {
   const router = useRouter()
@@ -15,10 +16,12 @@ export default function ProductUsageForm() {
   const [error, setError] = useState(null)
   const [success, setSuccess] = useState(false)
   const [alreadySubmitted, setAlreadySubmitted] = useState(false)
+  const [branding, setBranding] = useState(null)
 
   useEffect(() => {
     if (bookingId) {
       loadBookingAndProducts()
+      loadBranding()
     }
   }, [bookingId])
 
@@ -57,6 +60,18 @@ export default function ProductUsageForm() {
       setError(err.message)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const loadBranding = async () => {
+    try {
+      const res = await fetch('/api/get-branding')
+      if (res.ok) {
+        const data = await res.json()
+        setBranding(data.branding)
+      }
+    } catch (err) {
+      console.error('Error loading branding:', err)
     }
   }
 
@@ -177,9 +192,10 @@ export default function ProductUsageForm() {
         <Head>
           <title>Product Usage Already Logged - Keeping It Cute Salon</title>
         </Head>
-        <div style={{ 
-          fontFamily: 'Arial, sans-serif', 
-          backgroundColor: '#f8f9fa', 
+        <StaffNavBar branding={branding} activeTab="appointments" />
+        <div style={{
+          fontFamily: 'Arial, sans-serif',
+          backgroundColor: '#f8f9fa',
           minHeight: '100vh',
           padding: '20px'
         }}>
@@ -199,20 +215,7 @@ export default function ProductUsageForm() {
             <p style={{ color: '#666', marginBottom: '20px' }}>
               Product usage has already been recorded for this appointment.
             </p>
-            <button
-              onClick={() => router.push('/staff?tab=appointments')}
-              style={{
-                background: '#ff9a9e',
-                color: 'white',
-                border: 'none',
-                padding: '12px 25px',
-                borderRadius: '4px',
-                cursor: 'pointer',
-                fontSize: '16px'
-              }}
-            >
-              Back to Appointments
-            </button>
+            <div></div>
           </div>
         </div>
       </>
@@ -245,6 +248,8 @@ export default function ProductUsageForm() {
             Record products used during service
           </p>
         </div>
+
+        <StaffNavBar branding={branding} activeTab="appointments" />
 
         {success ? (
           <div style={{ 

--- a/pages/upload-product-images.js
+++ b/pages/upload-product-images.js
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
+import StaffNavBar from '../components/StaffNavBar'
 
 export default function UploadProductImages() {
   const router = useRouter()
@@ -12,9 +13,11 @@ export default function UploadProductImages() {
   const [dragOver, setDragOver] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [branding, setBranding] = useState(null)
 
   useEffect(() => {
     loadProducts()
+    loadBranding()
   }, [])
 
   const loadProducts = async () => {
@@ -31,6 +34,18 @@ export default function UploadProductImages() {
       console.error('Error loading products:', err)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const loadBranding = async () => {
+    try {
+      const res = await fetch('/api/get-branding')
+      if (res.ok) {
+        const data = await res.json()
+        setBranding(data.branding)
+      }
+    } catch (err) {
+      console.error('Error loading branding:', err)
     }
   }
 
@@ -179,22 +194,11 @@ export default function UploadProductImages() {
                 Add photos to your salon inventory ({products.length} total products)
               </p>
             </div>
-            <button
-              onClick={() => router.push('/staff?tab=inventory')}
-              style={{
-                background: 'rgba(255,255,255,0.2)',
-                color: 'white',
-                border: '1px solid rgba(255,255,255,0.3)',
-                padding: '10px 20px',
-                borderRadius: '6px',
-                cursor: 'pointer',
-                fontSize: '14px'
-              }}
-            >
-              ← Back to Inventory
-            </button>
+            <div></div>
           </div>
         </div>
+
+        <StaffNavBar branding={branding} activeTab="inventory" />
 
         <div style={{ maxWidth: '1000px', margin: '0 auto' }}>
           {/* Error Display */}


### PR DESCRIPTION
## Summary
- add shared `StaffNavBar` component
- fetch branding info and inject `StaffNavBar` in various staff pages
- highlight the active tab when navigating from inventory or appointments

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e1b2ff550832abaa7b9cb4b5aea94