### PR TITLE
Fix homepage fragment wrapping

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 // pages/index.js - Simple redirect to staff portal
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import Head from 'next/head'
 
 export default function Home() {
   const router = useRouter()
@@ -10,9 +11,14 @@ export default function Home() {
   }, [router])
   
   return (
-    <div style={{ padding: '20px', textAlign: 'center' }}>
-      <h1>Keeping It Cute Salon</h1>
-      <p>Redirecting to staff portal...</p>
-    </div>
+    <>
+      <Head>
+        <title>Home - Keeping It Cute Salon</title>
+      </Head>
+      <div style={{ padding: '20px', textAlign: 'center' }}>
+        <h1>Keeping It Cute Salon</h1>
+        <p>Redirecting to staff portal...</p>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- wrap the index page JSX with a fragment and include a `<Head>` element so the component returns a single parent

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1e263094832a835bc9bc2ebaa384