### PR TITLE
Show booking price even if zero

### DIFF
--- a/pages/staff.js
+++ b/pages/staff.js
@@ -801,14 +801,17 @@ export default function StaffPortal() {
                             {appointment.payment_status?.toUpperCase() || 'PENDING'}
                           </span>
 
-                          {appointment.total_price && (
-                            <span style={{
-                              fontSize: '1.1em',
-                              fontWeight: 'bold',
-                              color: '#333'
-                            }}>
-                              ${parseFloat(appointment.total_price).toFixed(2)}
-                            </span>
+                          {appointment.total_price !== undefined &&
+                            appointment.total_price !== null && (
+                              <span
+                                style={{
+                                  fontSize: '1.1em',
+                                  fontWeight: 'bold',
+                                  color: '#333'
+                                }}
+                              >
+                                ${parseFloat(appointment.total_price).toFixed(2)}
+                              </span>
                           )}
 
                           {appointment.status !== 'canceled' && (


### PR DESCRIPTION
## Summary
- ensure staff appointments always display the total price

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f22ad17f4832abadfa0526bce75e3