### PR TITLE
Add calendar view toggle for appointments

### DIFF
--- a/components/CalendarView.js
+++ b/components/CalendarView.js
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+
+export default function CalendarView({ appointments, onAppointmentClick }) {
+  const [currentDate, setCurrentDate] = useState(new Date())
+
+  const addMonths = (date, months) => {
+    const d = new Date(date)
+    d.setMonth(d.getMonth() + months)
+    return d
+  }
+
+  const startOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1)
+  const endOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 0)
+
+  const appointmentsByDate = appointments.reduce((acc, apt) => {
+    if (!apt.appointment_date) return acc
+    const dateKey = apt.appointment_date.slice(0, 10)
+    if (!acc[dateKey]) acc[dateKey] = []
+    acc[dateKey].push(apt)
+    return acc
+  }, {})
+
+  const days = []
+  const prefixBlanks = startOfMonth.getDay()
+  for (let i = 0; i < prefixBlanks; i++) {
+    days.push(null)
+  }
+  for (let d = 1; d <= endOfMonth.getDate(); d++) {
+    const date = new Date(currentDate.getFullYear(), currentDate.getMonth(), d)
+    const key = date.toISOString().slice(0, 10)
+    days.push({ date, appointments: appointmentsByDate[key] || [] })
+  }
+
+  const nextMonth = () => setCurrentDate(addMonths(currentDate, 1))
+  const prevMonth = () => setCurrentDate(addMonths(currentDate, -1))
+
+  const monthName = currentDate.toLocaleString('default', { month: 'long', year: 'numeric' })
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+        <button onClick={prevMonth} style={{ padding: '5px 10px' }}>«</button>
+        <h3 style={{ margin: 0 }}>{monthName}</h3>
+        <button onClick={nextMonth} style={{ padding: '5px 10px' }}>»</button>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', textAlign: 'center', marginBottom: '5px', fontWeight: 'bold' }}>
+        {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map(d => <div key={d}>{d}</div>)}
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '4px' }}>
+        {days.map((day, idx) => (
+          <div key={idx} style={{ minHeight: '80px', background: 'white', border: '1px solid #e9ecef', borderRadius: '4px', padding: '4px', fontSize: '0.8em' }}>
+            {day && (
+              <>
+                <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>{day.date.getDate()}</div>
+                {day.appointments.map(a => (
+                  <div key={a.id} onClick={() => onAppointmentClick && onAppointmentClick(a)} style={{ cursor: 'pointer', marginBottom: '2px', textAlign: 'left' }}>
+                    {new Date(a.appointment_date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} {a.customer_name || ''}
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import slugify from '../utils/slugify'
+import CalendarView from '../components/CalendarView'
 
 export default function StaffPortal() {
   const router = useRouter()
@@ -28,6 +29,7 @@ export default function StaffPortal() {
   const [savingNotes, setSavingNotes] = useState(false)
   const [appointmentSearch, setAppointmentSearch] = useState('')
   const [appointmentSort, setAppointmentSort] = useState('newest')
+  const [appointmentView, setAppointmentView] = useState('list')
 
   // Sync active tab with query string
   useEffect(() => {
@@ -736,11 +738,17 @@ export default function StaffPortal() {
                   <option value="newest">Newest</option>
                   <option value="oldest">Oldest</option>
                 </select>
+                <button
+                  onClick={() => setAppointmentView(appointmentView === 'list' ? 'calendar' : 'list')}
+                  style={{ padding: '10px', borderRadius: '4px', cursor: 'pointer' }}
+                >
+                  {appointmentView === 'list' ? 'Calendar View' : 'List View'}
+                </button>
                 <span style={{ alignSelf: 'center', fontWeight: 'bold' }}>Appointments: {appointments.length}</span>
               </div>
 
               {appointments.length === 0 ? (
-                <div style={{ 
+                <div style={{
                   background: 'white',
                   padding: '40px',
                   borderRadius: '12px',
@@ -753,6 +761,8 @@ export default function StaffPortal() {
                     Appointments will appear here once bookings are made through your Wix website.
                   </p>
                 </div>
+              ) : appointmentView === 'calendar' ? (
+                <CalendarView appointments={appointments} onAppointmentClick={handleAppointmentClick} />
               ) : (
                 <div style={{
                   display: 'grid',


### PR DESCRIPTION
## Summary
- create a simple CalendarView component
- add appointment view state to staff portal
- allow switching between list and calendar views

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686019f9f558832a9e006aebb44a5798