### PR TITLE
Improve calendar display with sorting

### DIFF
--- a/components/CalendarView.js
+++ b/components/CalendarView.js
@@ -12,13 +12,25 @@ export default function CalendarView({ appointments, onAppointmentClick }) {
   const startOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1)
   const endOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 0)
 
-  const appointmentsByDate = appointments.reduce((acc, apt) => {
+  // sort appointments by date so calendar always shows earliest first
+  const sortedAppointments = [...appointments].sort(
+    (a, b) => new Date(a.appointment_date) - new Date(b.appointment_date)
+  )
+
+  const appointmentsByDate = sortedAppointments.reduce((acc, apt) => {
     if (!apt.appointment_date) return acc
     const dateKey = apt.appointment_date.slice(0, 10)
     if (!acc[dateKey]) acc[dateKey] = []
     acc[dateKey].push(apt)
     return acc
   }, {})
+
+  // ensure appointments within each day are sorted
+  Object.keys(appointmentsByDate).forEach(key => {
+    appointmentsByDate[key].sort(
+      (a, b) => new Date(a.appointment_date) - new Date(b.appointment_date)
+    )
+  })
 
   const days = []
   const prefixBlanks = startOfMonth.getDay()
@@ -37,30 +49,52 @@ export default function CalendarView({ appointments, onAppointmentClick }) {
   const monthName = currentDate.toLocaleString('default', { month: 'long', year: 'numeric' })
 
   return (
-    <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
-        <button onClick={prevMonth} style={{ padding: '5px 10px' }}>«</button>
-        <h3 style={{ margin: 0 }}>{monthName}</h3>
-        <button onClick={nextMonth} style={{ padding: '5px 10px' }}>»</button>
+    <div style={{ background: 'white', padding: '20px', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '15px' }}>
+        <button onClick={prevMonth} style={{ padding: '8px 12px', borderRadius: '4px', border: '1px solid #ddd', background: '#f7f7f7', cursor: 'pointer' }}>«</button>
+        <h3 style={{ margin: 0, fontSize: '1.25em' }}>{monthName}</h3>
+        <button onClick={nextMonth} style={{ padding: '8px 12px', borderRadius: '4px', border: '1px solid #ddd', background: '#f7f7f7', cursor: 'pointer' }}>»</button>
       </div>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', textAlign: 'center', marginBottom: '5px', fontWeight: 'bold' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', textAlign: 'center', marginBottom: '10px', fontWeight: 'bold', color: '#555' }}>
         {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map(d => <div key={d}>{d}</div>)}
       </div>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '4px' }}>
-        {days.map((day, idx) => (
-          <div key={idx} style={{ minHeight: '80px', background: 'white', border: '1px solid #e9ecef', borderRadius: '4px', padding: '4px', fontSize: '0.8em' }}>
-            {day && (
-              <>
-                <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>{day.date.getDate()}</div>
-                {day.appointments.map(a => (
-                  <div key={a.id} onClick={() => onAppointmentClick && onAppointmentClick(a)} style={{ cursor: 'pointer', marginBottom: '2px', textAlign: 'left' }}>
-                    {new Date(a.appointment_date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} {a.customer_name || ''}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '8px' }}>
+        {days.map((day, idx) => {
+          const isToday = day && new Date().toDateString() === day.date.toDateString()
+          return (
+            <div
+              key={idx}
+              style={{
+                minHeight: '100px',
+                background: isToday ? '#e7f3ff' : '#fafafa',
+                border: '1px solid #e9ecef',
+                borderRadius: '8px',
+                padding: '6px',
+                fontSize: '0.85em',
+                display: 'flex',
+                flexDirection: 'column'
+              }}
+            >
+              {day && (
+                <>
+                  <div style={{ fontWeight: 'bold', marginBottom: '4px', color: isToday ? '#1976d2' : '#333' }}>
+                    {day.date.getDate()}
                   </div>
-                ))}
-              </>
-            )}
-          </div>
-        ))}
+                  {day.appointments.map(a => (
+                    <div
+                      key={a.id}
+                      onClick={() => onAppointmentClick && onAppointmentClick(a)}
+                      style={{ cursor: 'pointer', marginBottom: '2px', textAlign: 'left' }}
+                    >
+                      {new Date(a.appointment_date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}{' '}
+                      {a.customer_name || ''}
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- modernize the calendar view and highlight today's date
- sort appointments in ascending order so earliest appear first

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601b8e1fc8832aa811e176afe28462