### PR TITLE
Add OAuth note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ Copy `.env.example` to `.env.local` and fill in your Supabase credentials:
 - `SUPABASE_STORAGE_BUCKET` (e.g., `salon-images`)
 - `NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET` (same as above for the browser)
 - `WIX_API_TOKEN` Wix API token used for booking operations
+- `WIX_WEBHOOK_SECRET` secret used to verify Wix webhooks
+
+Generate these values in the **Wix Developer Center** by creating (or selecting)
+an app and navigating to **API Keys**. Create a new API key for server-to-server
+calls and copy it into `WIX_API_TOKEN`. Add a webhook secret and place its value
+in `WIX_WEBHOOK_SECRET`. Put both variables in `.env.local` during development or
+set them as environment variables in your deployment platform. The webhook
+secret is currently unused unless you implement request verification.
+
+Wix also supports **OAuth** authentication using an **App ID**, **App Secret**,
+and **instanceId**. This project relies on an API token for simplicity, but you
+can generate short-lived access tokens instead by following Wix's OAuth flow.
+Refer to the Wix Developer Center for details on obtaining your app credentials
+and creating an access token with the `/oauth2/token` endpoint.
 
 These values are required to build and run the API routes. Variables prefixed
 with `NEXT_PUBLIC_` are exposed to the browser, while server-side handlers rely


### PR DESCRIPTION
## Summary
- document OAuth as an alternative to the API token in the environment configuration

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605c594120832ab71b3ff9c242007d