### PR TITLE
Link bookings with salon_services

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE TABLE bookings (
   id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
   customer_id uuid,
+  service_id uuid REFERENCES salon_services(id),
   service text,
   start_time timestamptz,
   end_time timestamptz,

--- a/api/booking-updated.js
+++ b/api/booking-updated.js
@@ -48,6 +48,23 @@ export default async function handler(req, res) {
       updated_date: bookingData.updatedDate
     };
 
+    if (updateData.service_name) {
+      const { data: svc } = await supabase
+        .from('salon_services')
+        .select('id, duration_minutes, price')
+        .ilike('name', updateData.service_name)
+        .single();
+      if (svc) {
+        updateData.service_id = svc.id;
+        if (!updateData.service_duration) {
+          updateData.service_duration = svc.duration_minutes;
+        }
+        if (!updateData.total_price) {
+          updateData.total_price = svc.price;
+        }
+      }
+    }
+
     // Remove undefined values
     Object.keys(updateData).forEach(key => {
       if (updateData[key] === undefined) delete updateData[key];

--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -24,7 +24,7 @@ export default async function handler(req, res) {
     
     let query = supabase
       .from('bookings')
-      .select('*')
+      .select('*, salon_services(*)')
       .order('appointment_date', { ascending: false })
       .limit(parseInt(limit));
     

--- a/api/get-booking/[bookingId].js
+++ b/api/get-booking/[bookingId].js
@@ -29,7 +29,7 @@ export default async function handler(req, res) {
     // Get booking details
     const { data: booking, error } = await supabase
       .from('bookings')
-      .select('*')
+      .select('*, salon_services(*)')
       .eq('id', bookingId)
       .single();
     

--- a/migrations/20240102_add_service_id_to_bookings.sql
+++ b/migrations/20240102_add_service_id_to_bookings.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bookings
+ADD COLUMN IF NOT EXISTS service_id uuid REFERENCES salon_services(id);

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -1415,7 +1415,7 @@ export default function StaffPortal() {
                     <strong>Service:</strong> {selectedAppointment.service_name || 'Unknown Service'}
                   </div>
                   <div>
-                    <strong>Duration:</strong> {selectedAppointment.service_duration || 'Not specified'} minutes
+                    <strong>Duration:</strong> {selectedAppointment.service_duration || selectedAppointment.salon_services?.duration_minutes || 'Not specified'} minutes
                   </div>
                   <div>
                     <strong>Staff Member:</strong> {selectedAppointment.staff_member || 'Not assigned'}


### PR DESCRIPTION
## Summary
- reference services from `bookings`
- look up the service when creating or updating a booking
- include service details when fetching bookings or a single booking
- display appointment duration using linked service data
- document the new relationship and add a migration

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686091334d38832a834fda89a7a6fc8f