### PR TITLE
Add usage session controls

### DIFF
--- a/pages/staff.js
+++ b/pages/staff.js
@@ -270,6 +270,67 @@ export default function StaffPortal() {
     }
   }
 
+  const startUsageSession = async () => {
+    if (!selectedAppointment) return
+    try {
+      const response = await fetch('/api/start-usage-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          booking_id: selectedAppointment.id,
+          customer_name: selectedAppointment.customer_name,
+          service_performed: selectedAppointment.service_name,
+          staff_member: selectedAppointment.staff_member
+        })
+      })
+
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error)
+
+      setSelectedAppointment({
+        ...selectedAppointment,
+        has_product_usage: true,
+        product_usage_completed: false,
+        usage_session_id: data.session.id
+      })
+
+      alert('Usage session started')
+    } catch (error) {
+      console.error('Error starting usage session:', error)
+      alert('Failed to start usage session')
+    }
+  }
+
+  const endUsageSession = async () => {
+    if (!selectedAppointment) return
+    try {
+      const response = await fetch('/api/complete-usage-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          booking_id: selectedAppointment.id,
+          customer_name: selectedAppointment.customer_name,
+          service_performed: selectedAppointment.service_name,
+          staff_member: selectedAppointment.staff_member
+        })
+      })
+
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error)
+
+      setSelectedAppointment({
+        ...selectedAppointment,
+        has_product_usage: true,
+        product_usage_completed: true
+      })
+
+      alert('Usage session completed')
+    } catch (error) {
+      console.error('Error completing usage session:', error)
+      alert('Failed to complete usage session')
+    }
+  }
+
   const navigateToAudit = () => {
     router.push('/inventory-audit')
   }
@@ -1530,9 +1591,9 @@ export default function StaffPortal() {
 
                 {selectedAppointment.has_product_usage ? (
                   <div>
-                    <div style={{ 
-                      display: 'flex', 
-                      alignItems: 'center', 
+                    <div style={{
+                      display: 'flex',
+                      alignItems: 'center',
                       gap: '10px',
                       marginBottom: '15px'
                     }}>
@@ -1541,15 +1602,31 @@ export default function StaffPortal() {
                         Product usage has been logged for this appointment
                       </span>
                     </div>
-                    <p style={{ margin: '0', color: '#666', fontSize: '0.9em' }}>
+                    <p style={{ margin: '0 0 15px 0', color: '#666', fontSize: '0.9em' }}>
                       Status: {selectedAppointment.product_usage_completed ? 'Completed' : 'In Progress'}
                     </p>
+                    {!selectedAppointment.product_usage_completed && (
+                      <button
+                        onClick={endUsageSession}
+                        style={{
+                          background: '#4CAF50',
+                          color: 'white',
+                          border: 'none',
+                          padding: '10px 16px',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                          fontSize: '14px'
+                        }}
+                      >
+                        End Usage Session
+                      </button>
+                    )}
                   </div>
                 ) : (
                   <div>
-                    <div style={{ 
-                      display: 'flex', 
-                      alignItems: 'center', 
+                    <div style={{
+                      display: 'flex',
+                      alignItems: 'center',
                       gap: '10px',
                       marginBottom: '15px'
                     }}>
@@ -1561,23 +1638,39 @@ export default function StaffPortal() {
                     <p style={{ margin: '0 0 15px 0', color: '#666', fontSize: '0.9em' }}>
                       Record which products were used during this service for accurate inventory tracking.
                     </p>
-                    <button
-                      onClick={() => {
-                        window.open(`/product-usage/${selectedAppointment.id}`, '_blank')
-                      }}
-                      style={{
-                        background: '#ff9a9e',
-                        color: 'white',
-                        border: 'none',
-                        padding: '12px 20px',
-                        borderRadius: '6px',
-                        cursor: 'pointer',
-                        fontSize: '14px',
-                        fontWeight: 'bold'
-                      }}
-                    >
-                      📦 Log Product Usage
-                    </button>
+                    <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                      <button
+                        onClick={startUsageSession}
+                        style={{
+                          background: '#1976d2',
+                          color: 'white',
+                          border: 'none',
+                          padding: '10px 16px',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                          fontSize: '14px'
+                        }}
+                      >
+                        Start Usage Session
+                      </button>
+                      <button
+                        onClick={() => {
+                          window.open(`/product-usage/${selectedAppointment.id}`, '_blank')
+                        }}
+                        style={{
+                          background: '#ff9a9e',
+                          color: 'white',
+                          border: 'none',
+                          padding: '10px 16px',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                          fontSize: '14px',
+                          fontWeight: 'bold'
+                        }}
+                      >
+                        📦 Log Product Usage
+                      </button>
+                    </div>
                   </div>
                 )}
               </div>

--- a/tests/complete-usage-session.test.js
+++ b/tests/complete-usage-session.test.js
@@ -1,0 +1,57 @@
+const createQuery = (result) => {
+  const promise = Promise.resolve(result)
+  promise.select = jest.fn(() => promise)
+  promise.single = jest.fn(() => promise)
+  promise.eq = jest.fn(() => promise)
+  promise.update = jest.fn(() => promise)
+  promise.insert = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this }),
+  json: jest.fn(function(){ return this })
+})
+
+describe('complete-usage-session handler', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    process.env.SUPABASE_URL = 'http://example.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+  })
+
+  test('returns 405 on non-POST requests', async () => {
+    const from = jest.fn(() => createQuery({ data: {}, error: null }))
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/complete-usage-session.js')
+
+    const req = { method: 'GET', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('updates existing session and returns data', async () => {
+    const query = createQuery({ data: { id: 1 }, error: null })
+    const from = jest.fn(() => query)
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/complete-usage-session.js')
+
+    const req = { method: 'POST', body: { booking_id: 'b1' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('product_usage_sessions')
+    expect(query.update).toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'Usage session completed successfully' }))
+  })
+})

--- a/tests/start-usage-session.test.js
+++ b/tests/start-usage-session.test.js
@@ -1,0 +1,52 @@
+const createInsertQuery = (result) => {
+  const promise = Promise.resolve(result)
+  promise.insert = jest.fn(() => promise)
+  promise.select = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this }),
+  json: jest.fn(function(){ return this })
+})
+
+describe('start-usage-session handler', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    process.env.SUPABASE_URL = 'http://example.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+  })
+
+  test('returns 405 on non-POST requests', async () => {
+    const from = jest.fn(() => createInsertQuery({ data: [], error: null }))
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+
+    const { default: handler } = await import('../api/start-usage-session.js')
+
+    const req = { method: 'GET', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('inserts usage session and returns data', async () => {
+    const insertQuery = createInsertQuery({ data: [{ id: 1 }], error: null })
+    const from = jest.fn(() => insertQuery)
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+
+    const { default: handler } = await import('../api/start-usage-session.js')
+
+    const req = { method: 'POST', body: { booking_id: 'b1' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('product_usage_sessions')
+    expect(insertQuery.insert).toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'Usage session started successfully' }))
+  })
+})


### PR DESCRIPTION
## Summary
- allow staff to start or end a usage session from booking details
- add API unit tests for starting and completing usage sessions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686097366fbc832ab73d37773e96261e