### PR TITLE
Handle missing Supabase config in get appointments

### DIFF
--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -2,13 +2,30 @@
 import { createClient } from '@supabase/supabase-js'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('❌ Missing Supabase configuration', {
+    SUPABASE_URL: !!supabaseUrl,
+    SUPABASE_SERVICE_ROLE_KEY: !!supabaseKey
+  })
+}
+
+const supabase =
+  supabaseUrl && supabaseKey
+    ? createClient(supabaseUrl, supabaseKey)
+    : null
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET');
+
+  if (!supabaseUrl || !supabaseKey) {
+    console.error('❌ Missing Supabase configuration');
+    return res.status(500).json({
+      error: 'Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY'
+    });
+  }
   
   if (req.method === 'OPTIONS') {
     res.status(200).end();


### PR DESCRIPTION
## Summary
- fail fast when Supabase env vars are not set in `api/get-appointments.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a4958c5c832ab81a33462dd6b01b