### PR TITLE
Add booking creation and payment APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 - `GET /api/get-branding` - Retrieve salon branding details
 - `GET /api/get-orders` - List recent orders
 - `GET /api/get-customers` - Fetch customer records
+- `POST /api/create-booking` - Create a Wix appointment booking
+- `POST /api/create-checkout` - Generate a Wix checkout session for payments
 
 Example usage:
 
@@ -62,6 +64,13 @@ curl '/api/get-orders?limit=10'
 # Search for customers by name
 curl '/api/get-customers?search=jane'
 ```
+
+### Booking & Payments
+
+1. Call `/api/services` and `/api/query-availability` to display open slots.
+2. Send the chosen slot and customer details to `/api/create-booking`.
+3. Use the returned booking information to call `/api/create-checkout` and obtain a payment URL.
+4. Redirect the customer to the checkout URL to complete payment on Wix.
 
 ## 🚀 Quick Setup
 

--- a/api/create-booking.js
+++ b/api/create-booking.js
@@ -1,0 +1,88 @@
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'POST')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { serviceId, slot, contactDetails, ...rest } = req.body || {}
+
+  if (!serviceId || !slot || !contactDetails) {
+    return res
+      .status(400)
+      .json({ error: 'serviceId, slot and contactDetails are required' })
+  }
+
+  try {
+    // Call Wix Bookings API to create the booking
+    const wixRes = await fetch(
+      'https://www.wixapis.com/_api/bookings-service/v2/bookings',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify({
+          serviceId,
+          slot,
+          contactDetails,
+          ...rest
+        })
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res
+        .status(wixRes.status)
+        .json({ error: 'Failed to create booking', details: wixData })
+    }
+
+    const bookingInfo = wixData.booking || wixData
+
+    const bookingRecord = {
+      wix_booking_id: bookingInfo.id || bookingInfo.bookingId,
+      service_id: serviceId,
+      customer_email: contactDetails.email,
+      customer_name: `${contactDetails.firstName || ''} ${
+        contactDetails.lastName || ''
+      }`.trim(),
+      appointment_date: slot.startDate,
+      end_time: slot.endDate,
+      payment_status: 'not_paid',
+      status: 'pending',
+      payload: bookingInfo,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    }
+
+    const { data: booking, error } = await supabase
+      .from('bookings')
+      .insert([bookingRecord])
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Supabase booking insert error:', error)
+    }
+
+    res.status(200).json({ success: true, booking: booking || bookingRecord })
+  } catch (err) {
+    console.error('Create booking error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/api/create-checkout.js
+++ b/api/create-checkout.js
@@ -1,0 +1,46 @@
+import { setCorsHeaders } from '../utils/cors'
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'POST')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { lineItems, ...rest } = req.body || {}
+
+  if (!Array.isArray(lineItems) || lineItems.length === 0) {
+    return res.status(400).json({ error: 'lineItems are required' })
+  }
+
+  try {
+    const wixRes = await fetch(
+      'https://www.wixapis.com/ecom/v1/checkout',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify({ lineItems, ...rest })
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res
+        .status(wixRes.status)
+        .json({ error: 'Failed to create checkout', details: wixData })
+    }
+
+    res.status(200).json({ success: true, checkout: wixData })
+  } catch (err) {
+    console.error('Create checkout error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/tests/create-booking.test.js
+++ b/tests/create-booking.test.js
@@ -1,0 +1,95 @@
+const createInsert = (result) => {
+  const promise = Promise.resolve(result)
+  promise.insert = jest.fn(() => promise)
+  promise.select = jest.fn(() => promise)
+  promise.single = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function () { return this }),
+  json: jest.fn(function () { return this }),
+  end: jest.fn(function () { return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  process.env.SUPABASE_URL = 'http://example.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+  global.fetch = jest.fn()
+})
+
+afterEach(() => {
+  delete global.fetch
+})
+
+describe('create-booking handler', () => {
+  test('returns 405 on non-POST requests', async () => {
+    const from = jest.fn(() => createInsert({ data: {}, error: null }))
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/create-booking.js')
+
+    const req = { method: 'GET', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('validates required fields', async () => {
+    const from = jest.fn(() => createInsert({ data: {}, error: null }))
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/create-booking.js')
+
+    const req = { method: 'POST', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(String) })
+    )
+  })
+
+  test('calls wix API and inserts booking', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ booking: { id: '123' } })
+    })
+
+    const insertQuery = createInsert({ data: { id: '1' }, error: null })
+    const from = jest.fn(() => insertQuery)
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/create-booking.js')
+
+    const reqBody = {
+      serviceId: 'svc1',
+      slot: { startDate: '2024-01-01T10:00:00Z', endDate: '2024-01-01T11:00:00Z' },
+      contactDetails: { email: 'a@b.com', firstName: 'A', lastName: 'B' }
+    }
+    const req = { method: 'POST', body: reqBody }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://www.wixapis.com/_api/bookings-service/v2/bookings',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(reqBody)
+      })
+    )
+    expect(from).toHaveBeenCalledWith('bookings')
+    expect(insertQuery.insert).toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+})

--- a/tests/create-checkout.test.js
+++ b/tests/create-checkout.test.js
@@ -1,0 +1,70 @@
+const createRes = () => ({
+  status: jest.fn(function () { return this }),
+  json: jest.fn(function () { return this }),
+  end: jest.fn(function () { return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  global.fetch = jest.fn()
+})
+
+afterEach(() => {
+  delete global.fetch
+})
+
+describe('create-checkout handler', () => {
+  test('returns 405 on non-POST requests', async () => {
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+    const { default: handler } = await import('../api/create-checkout.js')
+
+    const req = { method: 'GET' }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('validates lineItems', async () => {
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+    const { default: handler } = await import('../api/create-checkout.js')
+
+    const req = { method: 'POST', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(String) })
+    )
+  })
+
+  test('calls wix API and returns data', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ id: 'co-1' })
+    })
+
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+    const { default: handler } = await import('../api/create-checkout.js')
+
+    const reqBody = { lineItems: [{ catalogReference: { id: '1' } }] }
+    const req = { method: 'POST', body: reqBody }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://www.wixapis.com/ecom/v1/checkout',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(reqBody)
+      })
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({ success: true, checkout: { id: 'co-1' } })
+  })
+})


### PR DESCRIPTION
## Summary
- introduce `/api/create-booking` to create Wix bookings
- add `/api/create-checkout` to start Wix payment flow
- document the new endpoints and booking flow in README
- include unit tests for the new handlers

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b55f95b4832a8a6a8c462f336cae