### PR TITLE
Add global mobile layout

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ErrorBoundary from '../components/ErrorBoundary'
+import '../styles/globals.css'
 
 export default function MyApp({ Component, pageProps }) {
   return (

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,15 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -388,7 +388,6 @@ export default function StaffPortal() {
     <>
       <Head>
         <title>Staff Portal - {branding?.salon_name || 'Keeping It Cute Salon & Spa'}</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href={branding?.logo_url || '/favicon.ico'} />
       </Head>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,32 @@
+html, body {
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+  font-family: Arial, sans-serif;
+}
+
+*, *::before, *::after {
+  box-sizing: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+.container {
+  width: 90%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+@media (max-width: 600px) {
+  body {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## Summary
- add global CSS for responsive design
- import CSS in `_app.js`
- create a custom `_document.js` to add viewport meta tag
- remove duplicate viewport tag from staff portal

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bee678f8832a8b340e14366747db