### PR TITLE
Fix action buttons mobile layout

### DIFF
--- a/pages/staff.js
+++ b/pages/staff.js
@@ -1623,7 +1623,8 @@ export default function StaffPortal() {
               <div style={{
                 display: 'flex',
                 gap: '15px',
-                justifyContent: 'flex-end'
+                flexWrap: 'wrap',
+                justifyContent: 'center'
               }}>
                 {selectedAppointment?.status !== 'canceled' && (
                   <>


### PR DESCRIPTION
## Summary
- wrap staff portal action buttons so they don't overflow on small screens

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e2fb2598832a8522a92e6f9b26c0