### PR TITLE
Add fallback placeholders for product images

### DIFF
--- a/pages/all-products.js
+++ b/pages/all-products.js
@@ -55,6 +55,13 @@ export default function AllProducts() {
       return
     }
 
+    const placeholder = '/images/products/placeholder.svg'
+    if (!e.target.dataset.placeholderTried) {
+      e.target.dataset.placeholderTried = 'true'
+      e.target.src = placeholder
+      return
+    }
+
     if (e.target.dataset.fallbackSet === 'true') return
 
     const width = e.target.offsetWidth || 200

--- a/pages/products/[productId].js
+++ b/pages/products/[productId].js
@@ -47,6 +47,13 @@ export default function ProductDetail() {
       return
     }
 
+    const placeholder = '/images/products/placeholder.svg'
+    if (!e.target.dataset.placeholderTried) {
+      e.target.dataset.placeholderTried = 'true'
+      e.target.src = placeholder
+      return
+    }
+
     if (e.target.dataset.fallbackSet === 'true') return
 
     const width = e.target.offsetWidth || 200

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -294,6 +294,13 @@ export default function StaffPortal() {
       return;
     }
 
+    const placeholder = '/images/products/placeholder.svg';
+    if (!e.target.dataset.placeholderTried) {
+      e.target.dataset.placeholderTried = 'true';
+      e.target.src = placeholder;
+      return;
+    }
+
     if (e.target.dataset.fallbackSet === 'true') return;
 
     const width = e.target.offsetWidth || 200;

--- a/public/images/products/bulk/default.svg
+++ b/public/images/products/bulk/default.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#f8f9fa" stroke="#dee2e6" stroke-width="2" />
+  <text x="100" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#666">Image</text>
+  <text x="100" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">Coming Soon</text>
+</svg>

--- a/public/images/products/hair-care/default.svg
+++ b/public/images/products/hair-care/default.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#f8f9fa" stroke="#dee2e6" stroke-width="2" />
+  <text x="100" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#666">Image</text>
+  <text x="100" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">Coming Soon</text>
+</svg>

--- a/public/images/products/other/default.svg
+++ b/public/images/products/other/default.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#f8f9fa" stroke="#dee2e6" stroke-width="2" />
+  <text x="100" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#666">Image</text>
+  <text x="100" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">Coming Soon</text>
+</svg>

--- a/public/images/products/placeholder.svg
+++ b/public/images/products/placeholder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#f8f9fa" stroke="#dee2e6" stroke-width="2" />
+  <text x="100" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#666">Image</text>
+  <text x="100" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">Coming Soon</text>
+</svg>

--- a/public/images/products/skincare/default.svg
+++ b/public/images/products/skincare/default.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#f8f9fa" stroke="#dee2e6" stroke-width="2" />
+  <text x="100" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#666">Image</text>
+  <text x="100" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">Coming Soon</text>
+</svg>

--- a/public/images/products/tools/default.svg
+++ b/public/images/products/tools/default.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#f8f9fa" stroke="#dee2e6" stroke-width="2" />
+  <text x="100" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#666">Image</text>
+  <text x="100" y="120" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#999">Coming Soon</text>
+</svg>


### PR DESCRIPTION
## Summary
- create a generic SVG placeholder for products
- use the placeholder when a product image cannot load
- include default placeholders in each product category directory

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686221424abc832a83294bf95d36f528