### PR TITLE
Add loyalty dashboard

### DIFF
--- a/api/get-loyalty.js
+++ b/api/get-loyalty.js
@@ -20,13 +20,25 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { limit = '50' } = req.query
+    const { limit = '50', email, contact_id } = req.query
 
-    const { data, error } = await supabase
-      .from('loyalty')
-      .select('*')
-      .limit(parseInt(limit))
-      .order('last_activity', { ascending: false })
+    let query = supabase.from('loyalty').select('*')
+
+    if (email) {
+      query = query.eq('email', email)
+    }
+
+    if (contact_id) {
+      query = query.eq('contact_id', contact_id)
+    }
+
+    if (!email && !contact_id) {
+      query = query.limit(parseInt(limit))
+    }
+
+    query = query.order('last_activity', { ascending: false })
+
+    const { data, error } = await query
 
     if (error) {
       console.error('❌ Loyalty fetch error:', error)

--- a/api/update-loyalty-points.js
+++ b/api/update-loyalty-points.js
@@ -1,0 +1,77 @@
+// api/update-loyalty-points.js - add or redeem loyalty points
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'POST')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const { loyalty_id, points = 0, action = 'add' } = req.body || {}
+
+    if (!loyalty_id || typeof points !== 'number') {
+      return res.status(400).json({ error: 'loyalty_id and numeric points are required' })
+    }
+
+    const { data: existing, error: fetchError } = await supabase
+      .from('loyalty')
+      .select('*')
+      .eq('id', loyalty_id)
+      .single()
+
+    if (fetchError) {
+      console.error('❌ Loyalty fetch error:', fetchError)
+      return res.status(500).json({ error: 'Failed to fetch loyalty record', details: fetchError.message })
+    }
+
+    let newBalance = existing.points_balance || 0
+    let newRedeemed = existing.redeemed_points || 0
+
+    if (action === 'redeem') {
+      newBalance -= points
+      newRedeemed += points
+    } else {
+      newBalance += points
+    }
+
+    if (newBalance < 0) newBalance = 0
+
+    const { data: updated, error: updateError } = await supabase
+      .from('loyalty')
+      .update({
+        points_balance: newBalance,
+        redeemed_points: newRedeemed,
+        last_activity: new Date().toISOString()
+      })
+      .eq('id', loyalty_id)
+      .select()
+      .single()
+
+    if (updateError) {
+      console.error('❌ Loyalty update error:', updateError)
+      return res.status(500).json({ error: 'Failed to update loyalty', details: updateError.message })
+    }
+
+    res.status(200).json({
+      success: true,
+      record: updated,
+      timestamp: new Date().toISOString()
+    })
+  } catch (err) {
+    console.error('❌ Update Loyalty Error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/pages/customers.js
+++ b/pages/customers.js
@@ -15,6 +15,7 @@ export default function CustomersPage() {
 
   const [selectedCustomer, setSelectedCustomer] = useState(null)
   const [showDetails, setShowDetails] = useState(false)
+  const [loyaltyRecord, setLoyaltyRecord] = useState(null)
 
   useEffect(() => {
     loadCustomers()
@@ -82,14 +83,25 @@ export default function CustomersPage() {
     return matchesSearch && matchesLabel
   })
 
-  const handleCustomerClick = (customer) => {
+  const handleCustomerClick = async (customer) => {
     setSelectedCustomer(customer)
     setShowDetails(true)
+    setLoyaltyRecord(null)
+    try {
+      const res = await fetch(`/api/get-loyalty?email=${encodeURIComponent(customer.email)}`)
+      if (res.ok) {
+        const data = await res.json()
+        setLoyaltyRecord((data.loyalty || [])[0] || null)
+      }
+    } catch (err) {
+      console.error('Failed to load loyalty', err)
+    }
   }
 
   const closeDetails = () => {
     setShowDetails(false)
     setSelectedCustomer(null)
+    setLoyaltyRecord(null)
   }
 
   if (loading) {
@@ -225,6 +237,15 @@ export default function CustomersPage() {
                     {selectedCustomer.address.region && <div>{selectedCustomer.address.region}</div>}
                     {selectedCustomer.address.postalCode && <div>{selectedCustomer.address.postalCode}</div>}
                     {selectedCustomer.address.country && <div>{selectedCustomer.address.country}</div>}
+                  </div>
+                </div>
+              )}
+              {loyaltyRecord && (
+                <div style={{ marginTop: '10px' }}>
+                  <strong>Loyalty Points:</strong>
+                  <div style={{ marginLeft: '10px' }}>
+                    <div>Balance: {loyaltyRecord.points_balance}</div>
+                    <div>Redeemed: {loyaltyRecord.redeemed_points}</div>
                   </div>
                 </div>
               )}

--- a/pages/customers.js
+++ b/pages/customers.js
@@ -120,19 +120,34 @@ export default function CustomersPage() {
       <div style={{ fontFamily: 'Arial, sans-serif', backgroundColor: '#f8f9fa', minHeight: '100vh', padding: '20px' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
           <h1 style={{ margin: 0 }}>👥 Customers</h1>
-          <button
-            onClick={() => router.push('/staff')}
-            style={{
-              background: 'linear-gradient(135deg, #e0cdbb 0%, #eee4da 100%)',
-              color: 'white',
-              border: 'none',
-              padding: '10px 20px',
-              borderRadius: '6px',
-              cursor: 'pointer'
-            }}
-          >
-            ← Back to Staff
-          </button>
+          <div style={{ display: 'flex', gap: '10px' }}>
+            <button
+              onClick={() => router.push('/loyalty-dashboard')}
+              style={{
+                background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                color: 'white',
+                border: 'none',
+                padding: '10px 20px',
+                borderRadius: '6px',
+                cursor: 'pointer'
+              }}
+            >
+              💎 Loyalty Dashboard
+            </button>
+            <button
+              onClick={() => router.push('/staff')}
+              style={{
+                background: 'linear-gradient(135deg, #e0cdbb 0%, #eee4da 100%)',
+                color: 'white',
+                border: 'none',
+                padding: '10px 20px',
+                borderRadius: '6px',
+                cursor: 'pointer'
+              }}
+            >
+              ← Back to Staff
+            </button>
+          </div>
         </div>
 
         {error && (

--- a/pages/loyalty-dashboard.js
+++ b/pages/loyalty-dashboard.js
@@ -1,0 +1,124 @@
+// pages/loyalty-dashboard.js
+import { useState, useEffect } from 'react'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+
+export default function LoyaltyDashboard() {
+  const router = useRouter()
+  const [records, setRecords] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [searchTerm, setSearchTerm] = useState('')
+
+  useEffect(() => { loadData() }, [])
+
+  const loadData = async () => {
+    try {
+      setLoading(true)
+      const res = await fetch('/api/get-loyalty?limit=200')
+      if (!res.ok) throw new Error('Failed to load loyalty records')
+      const data = await res.json()
+      setRecords(data.loyalty || [])
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const updatePoints = async (record, action) => {
+    const input = prompt(`How many points to ${action === 'add' ? 'add' : 'use'}?`)
+    const amt = parseInt(input, 10)
+    if (!amt || isNaN(amt)) return
+    try {
+      const res = await fetch('/api/update-loyalty-points', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ loyalty_id: record.id, points: amt, action })
+      })
+      if (res.ok) {
+        await loadData()
+      } else {
+        alert('Failed to update points')
+      }
+    } catch (err) {
+      alert('Failed to update points')
+    }
+  }
+
+  const filtered = records.filter(r => {
+    const term = searchTerm.toLowerCase()
+    return (
+      (r.name || '').toLowerCase().includes(term) ||
+      (r.email || '').toLowerCase().includes(term)
+    )
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Loyalty Dashboard - Keeping It Cute Salon</title>
+      </Head>
+      <div style={{ fontFamily: 'Arial, sans-serif', backgroundColor: '#f8f9fa', minHeight: '100vh', padding: '20px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
+          <h1 style={{ margin: 0 }}>💎 Loyalty Dashboard</h1>
+          <button
+            onClick={() => router.push('/staff')}
+            style={{
+              background: 'linear-gradient(135deg, #e0cdbb 0%, #eee4da 100%)',
+              color: 'white',
+              border: 'none',
+              padding: '10px 20px',
+              borderRadius: '6px',
+              cursor: 'pointer'
+            }}
+          >
+            ← Back to Staff
+          </button>
+        </div>
+        <input
+          type="text"
+          placeholder="Search loyalty..."
+          value={searchTerm}
+          onChange={e => setSearchTerm(e.target.value)}
+          style={{ padding: '10px', border: '1px solid #ddd', borderRadius: '4px', marginBottom: '20px', width: '100%', maxWidth: '300px' }}
+        />
+        {loading ? (
+          <p style={{ textAlign: 'center' }}>Loading loyalty...</p>
+        ) : error ? (
+          <p style={{ textAlign: 'center', color: 'red' }}>❌ {error}</p>
+        ) : (
+          <div style={{ background: 'white', borderRadius: '8px', boxShadow: '0 2px 4px rgba(0,0,0,0.1)', overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ background: '#f1f1f1', textAlign: 'left' }}>
+                  <th style={{ padding: '12px' }}>Name</th>
+                  <th style={{ padding: '12px' }}>Email</th>
+                  <th style={{ padding: '12px' }}>Balance</th>
+                  <th style={{ padding: '12px' }}>Redeemed</th>
+                  <th style={{ padding: '12px' }}>Last Activity</th>
+                  <th style={{ padding: '12px' }}>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map(r => (
+                  <tr key={r.id} style={{ borderTop: '1px solid #eee' }}>
+                    <td style={{ padding: '12px' }}>{r.name || 'N/A'}</td>
+                    <td style={{ padding: '12px' }}>{r.email}</td>
+                    <td style={{ padding: '12px' }}>{r.points_balance}</td>
+                    <td style={{ padding: '12px' }}>{r.redeemed_points}</td>
+                    <td style={{ padding: '12px' }}>{r.last_activity ? new Date(r.last_activity).toLocaleDateString() : ''}</td>
+                    <td style={{ padding: '12px' }}>
+                      <button onClick={() => updatePoints(r, 'add')} style={{ marginRight: '6px' }}>Add</button>
+                      <button onClick={() => updatePoints(r, 'redeem')}>Use</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -527,6 +527,22 @@ export default function StaffPortal() {
             >
               👥 View Customers
             </button>
+            <button
+              onClick={() => router.push('/loyalty-dashboard')}
+              style={{
+                background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                color: 'white',
+                border: 'none',
+                padding: '12px 20px',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                fontSize: '14px',
+                fontWeight: 'bold',
+                boxShadow: '0 2px 4px rgba(0,0,0,0.2)'
+              }}
+            >
+              💎 Loyalty Points
+            </button>
 
             {/* Action Buttons */}
             <div style={{ marginLeft: 'auto', display: 'flex', gap: '10px', alignItems: 'center' }}>

--- a/tests/update-loyalty-points.test.js
+++ b/tests/update-loyalty-points.test.js
@@ -1,0 +1,65 @@
+// tests for api/update-loyalty-points.js
+const createQuery = (result) => {
+  const promise = Promise.resolve(result)
+  promise.select = jest.fn(() => promise)
+  promise.update = jest.fn(() => promise)
+  promise.single = jest.fn(() => promise)
+  promise.eq = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this }),
+  json: jest.fn(function(){ return this }),
+  end: jest.fn(function(){ return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  process.env.SUPABASE_URL = 'http://example.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+})
+
+describe('update-loyalty-points handler', () => {
+  test('returns 405 on non-POST requests', async () => {
+    const from = jest.fn(() => createQuery({ data: {}, error: null }))
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/update-loyalty-points.js')
+
+    const req = { method: 'GET', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('updates loyalty record and returns result', async () => {
+    const selectQuery = createQuery({ data: { id: '1', points_balance: 10, redeemed_points: 0 }, error: null })
+    const updateQuery = createQuery({ data: { id: '1', points_balance: 15, redeemed_points: 0 }, error: null })
+    const from = jest.fn()
+      .mockReturnValueOnce(selectQuery)
+      .mockReturnValueOnce(updateQuery)
+
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/update-loyalty-points.js')
+
+    const req = { method: 'POST', body: { loyalty_id: '1', points: 5, action: 'add' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('loyalty')
+    expect(from).toHaveBeenCalledTimes(2)
+    expect(selectQuery.select).toHaveBeenCalledWith('*')
+    expect(selectQuery.eq).toHaveBeenCalledWith('id', '1')
+    expect(updateQuery.update).toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }))
+  })
+})


### PR DESCRIPTION
## Summary
- extend `get-loyalty` API with filters
- create API to update loyalty points
- show loyalty details on customer modal
- add loyalty points dashboard page and navigation link
- test new functionality

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644c8ff6a4832abe20d685faba725a