### PR TITLE
Add responsive layout and navigation

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router'
+import NavBar from './NavBar'
+
+export default function Layout({ children }) {
+  const router = useRouter()
+  const hideNavRoutes = ['/login', '/signup']
+  const showNav = !hideNavRoutes.includes(router.pathname)
+
+  return (
+    <>
+      {showNav && <NavBar />}
+      <main className="container">{children}</main>
+    </>
+  )
+}

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import Link from 'next/link'
+import styles from './NavBar.module.css'
+
+export default function NavBar() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <nav className={styles.navbar}>
+      <div className={styles.brand}>Keeping It Cute</div>
+      <button
+        className={styles.toggle}
+        onClick={() => setOpen(!open)}
+        aria-label="Toggle navigation"
+      >
+        &#9776;
+      </button>
+      <div className={`${styles.links} ${open ? styles.show : ''}`}>
+        <Link href="/staff">Staff</Link>
+        <Link href="/inventory-audit">Inventory</Link>
+        <Link href="/services">Services</Link>
+        <Link href="/alerts">Alerts</Link>
+      </div>
+    </nav>
+  )
+}

--- a/components/NavBar.module.css
+++ b/components/NavBar.module.css
@@ -1,0 +1,53 @@
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: #e0cdbb;
+  color: #333;
+}
+
+.brand {
+  font-weight: bold;
+  font-size: 1.25rem;
+}
+
+.links {
+  display: flex;
+  gap: 1rem;
+}
+
+.links a {
+  color: inherit;
+  font-weight: 500;
+}
+
+.toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: inherit;
+}
+
+@media (max-width: 768px) {
+  .toggle {
+    display: block;
+  }
+  .links {
+    position: absolute;
+    top: 56px;
+    left: 0;
+    right: 0;
+    background: #e0cdbb;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1rem;
+    display: none;
+  }
+  .show {
+    display: flex;
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import ErrorBoundary from '../components/ErrorBoundary'
+import Layout from '../components/Layout'
 import '../styles/globals.css'
 
 export default function MyApp({ Component, pageProps }) {
   return (
     <ErrorBoundary>
-      <Component {...pageProps} />
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
     </ErrorBoundary>
   )
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,8 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+
 html, body {
   padding: 0;
   margin: 0;
   box-sizing: border-box;
-  font-family: Arial, sans-serif;
+  font-family: 'Roboto', Arial, sans-serif;
+  background: #fdfdfd;
+  line-height: 1.6;
 }
 
 *, *::before, *::after {
@@ -23,6 +27,7 @@ img {
   width: 90%;
   max-width: 1200px;
   margin: 0 auto;
+  padding: 1rem;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- add responsive `NavBar` and `Layout` components
- wrap pages in layout via `_app.js`
- apply global Roboto font and container padding

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656297a1e8832a96ed2d640c6628a1