### PR TITLE
Add booking file uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 SUPABASE_STORAGE_BUCKET=salon-images
 NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET=salon-images
+SUPABASE_CLIENT_UPLOADS_BUCKET=client-uploads
+SUPABASE_RECEIPTS_BUCKET=product-usage-images
 
 # Optional: Webhook Security
 WIX_WEBHOOK_SECRET=your-wix-webhook-secret-for-verification

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Copy `.env.example` to `.env.local` and fill in your Supabase credentials:
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 - `SUPABASE_STORAGE_BUCKET` (e.g., `salon-images`)
 - `NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET` (same as above for the browser)
+- `SUPABASE_CLIENT_UPLOADS_BUCKET` bucket for before/after service photos
+- `SUPABASE_RECEIPTS_BUCKET` bucket for product usage receipts
 - `WIX_API_TOKEN` Wix API token used for booking operations
 - `WIX_WEBHOOK_SECRET` secret used to verify Wix webhooks
 
@@ -205,6 +207,13 @@ node scripts/create-placeholder-images.mjs
 ```
 
 The script is for development only and is not deployed as an API route.
+
+### Client Uploads
+
+Staff can attach before/after photos or other files to a booking. Files are
+uploaded to the `client-uploads` bucket and linked to the booking record. Use
+the `Upload Images` button on an appointment in the staff portal to manage
+these files.
 
 
 ## 🔧 Development Notes

--- a/api/get-booking-images/[bookingId].js
+++ b/api/get-booking-images/[bookingId].js
@@ -1,0 +1,39 @@
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../../utils/cors'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'GET')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const { bookingId } = req.query
+    if (!bookingId) {
+      return res.status(400).json({ error: 'Booking ID is required' })
+    }
+
+    const { data, error } = await supabase
+      .from('booking_images')
+      .select('*')
+      .eq('booking_id', bookingId)
+      .order('uploaded_at', { ascending: true })
+
+    if (error) throw error
+
+    res.status(200).json({ success: true, images: data || [] })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: err.message })
+  }
+}

--- a/api/upload-booking-file.js
+++ b/api/upload-booking-file.js
@@ -1,0 +1,86 @@
+import formidable from 'formidable'
+import fs from 'fs'
+import path from 'path'
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export const config = {
+  api: { bodyParser: false }
+}
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'POST')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, error: 'Method not allowed' })
+  }
+
+  try {
+    const bucket = process.env.SUPABASE_CLIENT_UPLOADS_BUCKET || 'client-uploads'
+
+    const form = formidable({ maxFileSize: 20 * 1024 * 1024, multiples: false })
+
+    const parse = () =>
+      new Promise((resolve, reject) => {
+        form.parse(req, (err, fields, files) => {
+          if (err) return reject(err)
+          resolve({ fields, files })
+        })
+      })
+
+    const { fields, files } = await parse()
+
+    const fileField = files.file || files.image || files.photo
+    if (!fileField) {
+      return res.status(400).json({ success: false, error: 'No file provided' })
+    }
+    const file = Array.isArray(fileField) ? fileField[0] : fileField
+
+    const bookingId = Array.isArray(fields.booking_id)
+      ? fields.booking_id[0]
+      : fields.booking_id
+
+    if (!bookingId) {
+      return res.status(400).json({ success: false, error: 'booking_id required' })
+    }
+
+    const ext = path.extname(file.originalFilename || '') || '.dat'
+    const filename = `booking-${bookingId}-${Date.now()}${ext}`
+    const storagePath = `booking-files/${bookingId}/${filename}`
+    const buffer = fs.readFileSync(file.filepath)
+    const { error: uploadError } = await supabase.storage
+      .from(bucket)
+      .upload(storagePath, buffer, { contentType: file.mimetype })
+    fs.unlinkSync(file.filepath)
+
+    if (uploadError) {
+      console.error(uploadError)
+      return res.status(500).json({ success: false, error: 'Upload failed' })
+    }
+
+    const { data: publicData } = supabase.storage.from(bucket).getPublicUrl(storagePath)
+    const fileUrl = publicData.publicUrl
+
+    await supabase.from('booking_images').insert({
+      booking_id: bookingId,
+      file_url: fileUrl,
+      file_name: filename,
+      file_type: file.mimetype
+    })
+
+    res.status(200).json({ success: true, file_url: fileUrl, file_name: filename })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ success: false, error: err.message })
+  }
+}

--- a/migrations/20240731_create_booking_images_table.sql
+++ b/migrations/20240731_create_booking_images_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS booking_images (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  booking_id uuid REFERENCES bookings(id) ON DELETE CASCADE,
+  file_url text,
+  file_name text,
+  uploaded_at timestamptz DEFAULT now(),
+  file_type text
+);

--- a/pages/booking-images/[bookingId].js
+++ b/pages/booking-images/[bookingId].js
@@ -1,0 +1,104 @@
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import StaffNavBar from '../../components/StaffNavBar'
+
+export default function BookingImages() {
+  const router = useRouter()
+  const { bookingId } = router.query
+  const [booking, setBooking] = useState(null)
+  const [images, setImages] = useState([])
+  const [file, setFile] = useState(null)
+  const [uploading, setUploading] = useState(false)
+  const [branding, setBranding] = useState(null)
+
+  useEffect(() => {
+    if (bookingId) {
+      loadBooking()
+      loadImages()
+      loadBranding()
+    }
+  }, [bookingId])
+
+  const loadBooking = async () => {
+    const res = await fetch(`/api/get-booking/${bookingId}`)
+    if (res.ok) {
+      const data = await res.json()
+      setBooking(data.booking)
+    }
+  }
+
+  const loadImages = async () => {
+    const res = await fetch(`/api/get-booking-images/${bookingId}`)
+    if (res.ok) {
+      const data = await res.json()
+      setImages(data.images || [])
+    }
+  }
+
+  const loadBranding = async () => {
+    const res = await fetch('/api/get-branding')
+    if (res.ok) {
+      const data = await res.json()
+      setBranding(data.branding)
+    }
+  }
+
+  const handleUpload = async (e) => {
+    e.preventDefault()
+    if (!file) return
+    setUploading(true)
+    const form = new FormData()
+    form.append('file', file)
+    form.append('booking_id', bookingId)
+
+    const res = await fetch('/api/upload-booking-file', {
+      method: 'POST',
+      body: form
+    })
+    if (res.ok) {
+      setFile(null)
+      await loadImages()
+    } else {
+      alert('Upload failed')
+    }
+    setUploading(false)
+  }
+
+  return (
+    <>
+      <Head><title>Booking Files</title></Head>
+      <StaffNavBar branding={branding} activeTab="appointments" />
+      <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+        <h1>Booking Files</h1>
+        {booking && (
+          <p>
+            {booking.customer_name} - {new Date(booking.appointment_date).toLocaleDateString()}
+          </p>
+        )}
+
+        <form onSubmit={handleUpload} style={{ marginBottom: '20px' }}>
+          <input
+            type="file"
+            onChange={(e) => setFile(e.target.files[0])}
+            style={{ marginRight: '10px' }}
+          />
+          <button type="submit" disabled={uploading || !file}>
+            {uploading ? 'Uploading...' : 'Upload'}
+          </button>
+        </form>
+
+        <div>
+          {images.map((img) => (
+            <div key={img.id} style={{ marginBottom: '10px' }}>
+              <a href={img.file_url} target="_blank" rel="noreferrer">
+                {img.file_name}
+              </a>
+            </div>
+          ))}
+          {images.length === 0 && <p>No files uploaded yet.</p>}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -1474,6 +1474,24 @@ export default function StaffPortal() {
                     >
                       📦 Log Product Usage
                     </button>
+                    <button
+                      onClick={() => {
+                        window.open(`/booking-images/${selectedAppointment.id}`, '_blank')
+                      }}
+                      style={{
+                        background: '#1976d2',
+                        color: 'white',
+                        border: 'none',
+                        padding: '12px 20px',
+                        borderRadius: '6px',
+                        cursor: 'pointer',
+                        fontSize: '14px',
+                        fontWeight: 'bold',
+                        marginLeft: '10px'
+                      }}
+                    >
+                      📷 Upload Images
+                    </button>
                   </div>
                 )}
               </div>
@@ -1591,6 +1609,24 @@ export default function StaffPortal() {
                     📦 Log Product Usage
                   </button>
                 )}
+                <button
+                  onClick={() => {
+                    window.open(`/booking-images/${selectedAppointment.id}`, '_blank')
+                  }}
+                  style={{
+                    background: '#1976d2',
+                    color: 'white',
+                    border: 'none',
+                    padding: '12px 20px',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontSize: '14px',
+                    fontWeight: 'bold',
+                    marginLeft: '10px'
+                  }}
+                >
+                  📷 Upload Images
+                </button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- allow before/after service uploads
- store images in new `booking_images` table
- expose `/api/upload-booking-file` and `/api/get-booking-images/[bookingId]`
- add client upload buckets to env and docs
- support upload UI from staff portal

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865fa981c9c832ab3e734aa32174f7f