### PR TITLE
Fix fallback error handling in inventory alerts

### DIFF
--- a/api/get-inventory-alerts.js
+++ b/api/get-inventory-alerts.js
@@ -42,6 +42,8 @@ export default async function handler(req, res) {
 
       if (fallback.error) {
         error = fallback.error
+      } else {
+        error = null
       }
 
       lowStockProducts = (fallback.data || []).filter(p =>


### PR DESCRIPTION
## Summary
- clear error variable when RPC fallback succeeds in `get-inventory-alerts.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865fe957428832ab782183b079bf1f1