### PR TITLE
Implement appointment paging and filtering

### DIFF
--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -20,20 +20,50 @@ export default async function handler(req, res) {
   }
   
   try {
-    const { limit = '50', status, payment_status } = req.query;
-    
+    const {
+      limit = '50',
+      page = '1',
+      status,
+      payment_status,
+      staff_member,
+      start_date,
+      end_date
+    } = req.query;
+
+    const lim = parseInt(limit);
+    const pg = parseInt(page);
+
     let query = supabase
       .from('bookings')
       .select('*, salon_services(*)')
-      .order('appointment_date', { ascending: false })
-      .limit(parseInt(limit));
+      .order('appointment_date', { ascending: false });
+
+    if (!Number.isNaN(lim) && !Number.isNaN(pg)) {
+      const from = (pg - 1) * lim;
+      const to = from + lim - 1;
+      query = query.range(from, to);
+    } else if (!Number.isNaN(lim)) {
+      query = query.limit(lim);
+    }
     
     if (status) {
       query = query.eq('status', status);
     }
-    
+
     if (payment_status) {
       query = query.eq('payment_status', payment_status);
+    }
+
+    if (staff_member) {
+      query = query.eq('staff_member', staff_member);
+    }
+
+    if (start_date) {
+      query = query.gte('appointment_date', start_date);
+    }
+
+    if (end_date) {
+      query = query.lte('appointment_date', end_date);
     }
     
     const { data: appointments, error } = await query;

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import slugify from '../utils/slugify'
+import { buildAppointmentsQuery } from '../utils/appointments'
 
 // Determine if a product image URL from Wix is unusable in the browser
 const isWixImage = (url) => url && url.startsWith('wix:image://')
@@ -41,6 +42,13 @@ export default function StaffPortal() {
   const [appointmentSearch, setAppointmentSearch] = useState('')
   const [appointmentSort, setAppointmentSort] = useState('newest')
   const [appointmentView, setAppointmentView] = useState('list')
+  const pageSize = 50
+  const [currentPage, setCurrentPage] = useState(1)
+  const [filterStatus, setFilterStatus] = useState('')
+  const [filterPaymentStatus, setFilterPaymentStatus] = useState('')
+  const [filterStaff, setFilterStaff] = useState('')
+  const [filterStartDate, setFilterStartDate] = useState('')
+  const [filterEndDate, setFilterEndDate] = useState('')
 
   // Sync active tab with query string
   useEffect(() => {
@@ -52,6 +60,30 @@ export default function StaffPortal() {
   useEffect(() => {
     loadData()
   }, [])
+
+  const fetchAppointments = async (pageNum = currentPage) => {
+    try {
+      const params = buildAppointmentsQuery({
+        page: pageNum,
+        limit: pageSize,
+        status: filterStatus,
+        payment_status: filterPaymentStatus,
+        staff_member: filterStaff,
+        start_date: filterStartDate,
+        end_date: filterEndDate
+      })
+
+      const appointmentsResponse = await fetch(`/api/get-appointments?${params}`)
+      if (!appointmentsResponse.ok) {
+        throw new Error(`Appointments API Error: ${appointmentsResponse.status}`)
+      }
+      const appointmentsData = await appointmentsResponse.json()
+      console.log('Appointments loaded:', appointmentsData.count)
+      setAppointments(appointmentsData.appointments || [])
+    } catch (err) {
+      console.error('Error loading appointments:', err)
+    }
+  }
 
   const loadData = async () => {
     try {
@@ -83,13 +115,8 @@ export default function StaffPortal() {
       const servicesData = await servicesResponse.json()
       console.log('Services loaded:', servicesData.stats?.total_services)
 
-      // Load appointments
-      const appointmentsResponse = await fetch('/api/get-appointments')
-      if (!appointmentsResponse.ok) {
-        throw new Error(`Appointments API Error: ${appointmentsResponse.status}`)
-      }
-      const appointmentsData = await appointmentsResponse.json()
-      console.log('Appointments loaded:', appointmentsData.count)
+      // Load first page of appointments
+      await fetchAppointments(1)
 
       // Load alerts and notifications
       const alertsResponse = await fetch('/api/get-inventory-alerts')
@@ -109,7 +136,6 @@ export default function StaffPortal() {
       setProducts(productsData.products || [])
       setMadamGlamCount(madamGlamCount)
       setServices(servicesData.services || [])
-      setAppointments(appointmentsData.appointments || [])
       setLoading(false)
 
     } catch (error) {
@@ -118,6 +144,12 @@ export default function StaffPortal() {
       setLoading(false)
     }
   }
+
+  useEffect(() => {
+    if (!loading) {
+      fetchAppointments()
+    }
+  }, [currentPage, filterStatus, filterPaymentStatus, filterStaff, filterStartDate, filterEndDate])
 
   const handleProductClick = (product) => {
     setSelectedProduct(product)
@@ -632,6 +664,19 @@ export default function StaffPortal() {
                   <option value="newest">Newest</option>
                   <option value="oldest">Oldest</option>
                 </select>
+                <select value={filterStatus} onChange={e => { setFilterStatus(e.target.value); setCurrentPage(1) }} style={{ padding: '10px', borderRadius: '4px' }}>
+                  <option value="">All Statuses</option>
+                  <option value="confirmed">Confirmed</option>
+                  <option value="canceled">Canceled</option>
+                </select>
+                <select value={filterPaymentStatus} onChange={e => { setFilterPaymentStatus(e.target.value); setCurrentPage(1) }} style={{ padding: '10px', borderRadius: '4px' }}>
+                  <option value="">All Payments</option>
+                  <option value="paid">Paid</option>
+                  <option value="unpaid">Unpaid</option>
+                </select>
+                <input type="text" placeholder="Staff" value={filterStaff} onChange={e => { setFilterStaff(e.target.value); setCurrentPage(1) }} style={{ padding: '10px', border: '1px solid #ddd', borderRadius: '4px' }} />
+                <input type="date" value={filterStartDate} onChange={e => { setFilterStartDate(e.target.value); setCurrentPage(1) }} style={{ padding: '10px', border: '1px solid #ddd', borderRadius: '4px' }} />
+                <input type="date" value={filterEndDate} onChange={e => { setFilterEndDate(e.target.value); setCurrentPage(1) }} style={{ padding: '10px', border: '1px solid #ddd', borderRadius: '4px' }} />
                 <button
                   onClick={() => setAppointmentView(appointmentView === 'list' ? 'calendar' : 'list')}
                   style={{ padding: '10px', borderRadius: '4px', cursor: 'pointer' }}
@@ -675,7 +720,7 @@ export default function StaffPortal() {
                       }
                       return new Date(b.appointment_date) - new Date(a.appointment_date)
                     })
-                    return sorted.slice(0, 20).map((appointment) => (
+                    return sorted.map((appointment) => (
                     <div
                       key={appointment.id}
                       onClick={() => handleAppointmentClick(appointment)}
@@ -835,6 +880,11 @@ export default function StaffPortal() {
                     </div>
                     ))
                   })()}
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', marginTop: '20px' }}>
+                  <button onClick={() => setCurrentPage(p => Math.max(1, p - 1))} disabled={currentPage === 1}>Previous</button>
+                  <span>Page {currentPage}</span>
+                  <button onClick={() => setCurrentPage(p => p + 1)} disabled={appointments.length < pageSize}>Next</button>
                 </div>
               )}
             </div>

--- a/tests/appointments-utils.test.js
+++ b/tests/appointments-utils.test.js
@@ -1,0 +1,16 @@
+const { buildAppointmentsQuery } = require('../utils/appointments')
+
+test('buildAppointmentsQuery returns query string with params', () => {
+  const q = buildAppointmentsQuery({
+    page: 2,
+    limit: 10,
+    status: 'confirmed',
+    payment_status: 'paid',
+    staff_member: 'Jane',
+    start_date: '2024-01-01',
+    end_date: '2024-01-31'
+  })
+  expect(q).toBe('page=2&limit=10&status=confirmed&payment_status=paid&staff_member=Jane&start_date=2024-01-01&end_date=2024-01-31')
+})
+
+

--- a/tests/get-appointments.test.js
+++ b/tests/get-appointments.test.js
@@ -1,0 +1,72 @@
+const createQuery = (result) => {
+  const promise = Promise.resolve(result)
+  promise.select = jest.fn(() => promise)
+  promise.order = jest.fn(() => promise)
+  promise.range = jest.fn(() => promise)
+  promise.eq = jest.fn(() => promise)
+  promise.gte = jest.fn(() => promise)
+  promise.lte = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this }),
+  json: jest.fn(function(){ return this }),
+  end: jest.fn(function(){ return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  process.env.SUPABASE_URL = 'http://example.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+})
+
+describe('get-appointments handler', () => {
+  test('returns 405 on non-GET requests', async () => {
+    const from = jest.fn(() => createQuery({ data: [], error: null }))
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/get-appointments.js')
+
+    const req = { method: 'POST', query: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('uses query params for pagination and filtering', async () => {
+    const appointments = [{ id: 1 }]
+    const query = createQuery({ data: appointments, error: null })
+    const from = jest.fn(() => query)
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/get-appointments.js')
+
+    const req = { method: 'GET', query: { page: '2', limit: '10', status: 'confirmed', payment_status: 'paid', staff_member: 'Jane', start_date: '2024-01-01', end_date: '2024-01-31' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('bookings')
+    expect(query.select).toHaveBeenCalledWith('*, salon_services(*)')
+    expect(query.order).toHaveBeenCalledWith('appointment_date', { ascending: false })
+    expect(query.range).toHaveBeenCalledWith(10, 19)
+    expect(query.eq.mock.calls).toEqual(expect.arrayContaining([
+      ['status', 'confirmed'],
+      ['payment_status', 'paid'],
+      ['staff_member', 'Jane']
+    ]))
+    expect(query.gte).toHaveBeenCalledWith('appointment_date', '2024-01-01')
+    expect(query.lte).toHaveBeenCalledWith('appointment_date', '2024-01-31')
+
+    const response = res.json.mock.calls[0][0]
+    expect(response).toMatchObject({ success: true, appointments, count: appointments.length })
+    expect(typeof response.timestamp).toBe('string')
+  })
+})
+

--- a/utils/appointments.js
+++ b/utils/appointments.js
@@ -1,0 +1,10 @@
+export function buildAppointmentsQuery({ page = 1, limit = 50, status, payment_status, staff_member, start_date, end_date } = {}) {
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) })
+  if (status) params.append('status', status)
+  if (payment_status) params.append('payment_status', payment_status)
+  if (staff_member) params.append('staff_member', staff_member)
+  if (start_date) params.append('start_date', start_date)
+  if (end_date) params.append('end_date', end_date)
+  return params.toString()
+}
+


### PR DESCRIPTION
## Summary
- add page/limit and filtering support to `get-appointments` API
- build appointment query strings in shared util
- support pagination, filters and navigation in staff portal
- cover API and util logic with tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866aed0bf64832ab288b199f84b2506