### PR TITLE
Refactor appointment list map

### DIFF
--- a/pages/staff.js
+++ b/pages/staff.js
@@ -402,6 +402,22 @@ export default function StaffPortal() {
     return acc
   }, {})
 
+  // Appointment list helpers
+  const term = appointmentSearch.toLowerCase()
+  const filtered = appointments.filter(
+    (a) =>
+      (a.customer_name || '').toLowerCase().includes(term) ||
+      (a.customer_email || '').toLowerCase().includes(term)
+  )
+  const sorted = filtered
+    .sort((a, b) => {
+      if (appointmentSort === 'oldest') {
+        return new Date(a.appointment_date) - new Date(b.appointment_date)
+      }
+      return new Date(b.appointment_date) - new Date(a.appointment_date)
+    })
+    .slice(0, 20)
+
   return (
     <>
       <Head>
@@ -663,24 +679,12 @@ export default function StaffPortal() {
                   gridTemplateColumns: 'repeat(auto-fit, minmax(400px, 1fr))',
                   gap: '20px'
                 }}>
-                  {(() => {
-                    const term = appointmentSearch.toLowerCase()
-                    const filtered = appointments.filter(a =>
-                      (a.customer_name || '').toLowerCase().includes(term) ||
-                      (a.customer_email || '').toLowerCase().includes(term)
-                    )
-                    const sorted = filtered.sort((a, b) => {
-                      if (appointmentSort === 'oldest') {
-                        return new Date(a.appointment_date) - new Date(b.appointment_date)
-                      }
-                      return new Date(b.appointment_date) - new Date(a.appointment_date)
-                    })
-                    return sorted.slice(0, 20).map((appointment) => (
+                  {sorted.map((appointment) => (
                     <div
                       key={appointment.id}
                       onClick={() => handleAppointmentClick(appointment)}
-                      style={{ 
-                        background: 'white', 
+                      style={{
+                        background: 'white',
                         border: '1px solid #e9ecef', 
                         borderRadius: '12px',
                         padding: '20px',
@@ -833,8 +837,7 @@ export default function StaffPortal() {
                         </div>
                       )}
                     </div>
-                    ))
-                  })()}
+                  ))}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- clean up appointment filtering logic
- compute search and sorting variables outside of JSX
- render appointments without an inline IIFE

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ba97d4f8832aa34bdf772f5144dd