### PR TITLE
Add pagination util with clamping and tests

### DIFF
--- a/tests/appointments-utils.test.js
+++ b/tests/appointments-utils.test.js
@@ -1,0 +1,16 @@
+const { clampPagination } = require('../utils/appointments');
+
+describe('clampPagination', () => {
+  test('returns positive integers for valid input', () => {
+    expect(clampPagination('2', '10')).toEqual({ page: 2, limit: 10 });
+  });
+
+  test('clamps zero or negative values', () => {
+    expect(clampPagination('0', '0')).toEqual({ page: 1, limit: 50 });
+    expect(clampPagination('-3', '-5')).toEqual({ page: 1, limit: 50 });
+  });
+
+  test('handles non-numeric values', () => {
+    expect(clampPagination('abc', 'xyz')).toEqual({ page: 1, limit: 50 });
+  });
+});

--- a/utils/appointments.js
+++ b/utils/appointments.js
@@ -1,0 +1,9 @@
+function clampPagination(page = 1, limit = 50) {
+  const p = parseInt(page, 10);
+  const l = parseInt(limit, 10);
+  const safePage = Number.isFinite(p) && p >= 1 ? p : 1;
+  const safeLimit = Number.isFinite(l) && l > 0 ? l : 50;
+  return { page: safePage, limit: safeLimit };
+}
+
+module.exports = { clampPagination };


### PR DESCRIPTION
## Summary
- implement `utils/appointments.js` with `clampPagination` that ensures page and limit are positive numbers
- create unit tests covering valid, zero/negative and non-numeric values

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bba9c77c832a8cf61eace335a969