### PR TITLE
Validate page and limit in appointments

### DIFF
--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -20,13 +20,19 @@ export default async function handler(req, res) {
   }
   
   try {
-    const { limit = '50', status, payment_status } = req.query;
+    const { page = '1', limit = '50', status, payment_status } = req.query;
+
+    const pageNum = parseInt(page, 10);
+    const limitNum = parseInt(limit, 10);
+    if (!Number.isFinite(pageNum) || pageNum < 1 || !Number.isFinite(limitNum) || limitNum < 1) {
+      return res.status(400).json({ error: 'Invalid page or limit parameter' });
+    }
     
     let query = supabase
       .from('bookings')
       .select('*, salon_services(*)')
       .order('appointment_date', { ascending: false })
-      .limit(parseInt(limit));
+      .limit(limitNum);
     
     if (status) {
       query = query.eq('status', status);

--- a/tests/get-appointments.test.js
+++ b/tests/get-appointments.test.js
@@ -1,0 +1,55 @@
+// tests for api/get-appointments.js
+const createQuery = (result) => {
+  const promise = Promise.resolve(result);
+  promise.select = jest.fn(() => promise);
+  promise.order = jest.fn(() => promise);
+  promise.limit = jest.fn(() => promise);
+  promise.eq = jest.fn(() => promise);
+  return promise;
+};
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this; }),
+  json: jest.fn(function(){ return this; }),
+  end: jest.fn(function(){ return this; })
+});
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env.SUPABASE_URL = 'http://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+});
+
+describe('get-appointments handler', () => {
+  test('rejects non-positive page or limit', async () => {
+    const from = jest.fn(() => createQuery({ data: [], error: null }));
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+
+    const { default: handler } = await import('../api/get-appointments.js');
+
+    const req = { method: 'GET', query: { page: '0', limit: '-1' } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid page or limit parameter' });
+  });
+
+  test('rejects non-numeric page or limit', async () => {
+    const from = jest.fn(() => createQuery({ data: [], error: null }));
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+
+    const { default: handler } = await import('../api/get-appointments.js');
+
+    const req = { method: 'GET', query: { page: 'abc', limit: 'ten' } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid page or limit parameter' });
+  });
+});


### PR DESCRIPTION
## Summary
- check page and limit query params in `get-appointments`
- test invalid pagination parameters

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bdbfd178832a9e1cece896c3dd56