### PR TITLE
Implement appointment paging and filtering

### DIFF
--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -20,20 +20,50 @@ export default async function handler(req, res) {
   }
   
   try {
-    const { limit = '50', status, payment_status } = req.query;
-    
+    const {
+      limit = '50',
+      page = '1',
+      status,
+      payment_status,
+      staff_member,
+      start_date,
+      end_date
+    } = req.query;
+
+    const lim = parseInt(limit);
+    const pg = parseInt(page);
+
     let query = supabase
       .from('bookings')
       .select('*, salon_services(*)')
-      .order('appointment_date', { ascending: false })
-      .limit(parseInt(limit));
+      .order('appointment_date', { ascending: false });
+
+    if (!Number.isNaN(lim) && !Number.isNaN(pg)) {
+      const from = (pg - 1) * lim;
+      const to = from + lim - 1;
+      query = query.range(from, to);
+    } else if (!Number.isNaN(lim)) {
+      query = query.limit(lim);
+    }
     
     if (status) {
       query = query.eq('status', status);
     }
-    
+
     if (payment_status) {
       query = query.eq('payment_status', payment_status);
+    }
+
+    if (staff_member) {
+      query = query.eq('staff_member', staff_member);
+    }
+
+    if (start_date) {
+      query = query.gte('appointment_date', start_date);
+    }
+
+    if (end_date) {
+      query = query.lte('appointment_date', end_date);
     }
     
     const { data: appointments, error } = await query;

--- a/tests/appointments-utils.test.js
+++ b/tests/appointments-utils.test.js
@@ -1,0 +1,16 @@
+const { buildAppointmentsQuery } = require('../utils/appointments')
+
+test('buildAppointmentsQuery returns query string with params', () => {
+  const q = buildAppointmentsQuery({
+    page: 2,
+    limit: 10,
+    status: 'confirmed',
+    payment_status: 'paid',
+    staff_member: 'Jane',
+    start_date: '2024-01-01',
+    end_date: '2024-01-31'
+  })
+  expect(q).toBe('page=2&limit=10&status=confirmed&payment_status=paid&staff_member=Jane&start_date=2024-01-01&end_date=2024-01-31')
+})
+
+

--- a/tests/get-appointments.test.js
+++ b/tests/get-appointments.test.js
@@ -1,0 +1,72 @@
+const createQuery = (result) => {
+  const promise = Promise.resolve(result)
+  promise.select = jest.fn(() => promise)
+  promise.order = jest.fn(() => promise)
+  promise.range = jest.fn(() => promise)
+  promise.eq = jest.fn(() => promise)
+  promise.gte = jest.fn(() => promise)
+  promise.lte = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this }),
+  json: jest.fn(function(){ return this }),
+  end: jest.fn(function(){ return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  process.env.SUPABASE_URL = 'http://example.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+})
+
+describe('get-appointments handler', () => {
+  test('returns 405 on non-GET requests', async () => {
+    const from = jest.fn(() => createQuery({ data: [], error: null }))
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/get-appointments.js')
+
+    const req = { method: 'POST', query: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('uses query params for pagination and filtering', async () => {
+    const appointments = [{ id: 1 }]
+    const query = createQuery({ data: appointments, error: null })
+    const from = jest.fn(() => query)
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/get-appointments.js')
+
+    const req = { method: 'GET', query: { page: '2', limit: '10', status: 'confirmed', payment_status: 'paid', staff_member: 'Jane', start_date: '2024-01-01', end_date: '2024-01-31' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('bookings')
+    expect(query.select).toHaveBeenCalledWith('*, salon_services(*)')
+    expect(query.order).toHaveBeenCalledWith('appointment_date', { ascending: false })
+    expect(query.range).toHaveBeenCalledWith(10, 19)
+    expect(query.eq.mock.calls).toEqual(expect.arrayContaining([
+      ['status', 'confirmed'],
+      ['payment_status', 'paid'],
+      ['staff_member', 'Jane']
+    ]))
+    expect(query.gte).toHaveBeenCalledWith('appointment_date', '2024-01-01')
+    expect(query.lte).toHaveBeenCalledWith('appointment_date', '2024-01-31')
+
+    const response = res.json.mock.calls[0][0]
+    expect(response).toMatchObject({ success: true, appointments, count: appointments.length })
+    expect(typeof response.timestamp).toBe('string')
+  })
+})
+

--- a/utils/appointments.js
+++ b/utils/appointments.js
@@ -1,0 +1,10 @@
+export function buildAppointmentsQuery({ page = 1, limit = 50, status, payment_status, staff_member, start_date, end_date } = {}) {
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) })
+  if (status) params.append('status', status)
+  if (payment_status) params.append('payment_status', payment_status)
+  if (staff_member) params.append('staff_member', staff_member)
+  if (start_date) params.append('start_date', start_date)
+  if (end_date) params.append('end_date', end_date)
+  return params.toString()
+}
+


### PR DESCRIPTION
## Summary
- add page/limit and filtering support to `get-appointments` API
- build appointment query strings in shared util
- support pagination, filters and navigation in staff portal
- cover API and util logic with tests
- fix JSX rendering of appointment notes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866aed0bf64832ab288b199f84b2506