### PR TITLE
Add basic business dashboard page

### DIFF
--- a/api/get-dashboard-metrics.js
+++ b/api/get-dashboard-metrics.js
@@ -1,0 +1,35 @@
+// api/get-dashboard-metrics.js
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'GET')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const { data, error } = await supabase.rpc('dashboard_metrics')
+    if (error) {
+      throw error
+    }
+    res.status(200).json({ success: true, metrics: data ? data[0] : {} })
+  } catch (err) {
+    console.error('Dashboard Metrics Error:', err)
+    res.status(500).json({
+      error: 'Failed to fetch dashboard metrics',
+      details: err.message
+    })
+  }
+}

--- a/migrations/20240915_create_dashboard_metrics_function.sql
+++ b/migrations/20240915_create_dashboard_metrics_function.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION dashboard_metrics()
+RETURNS TABLE(
+  upcoming_appointments integer,
+  product_usage_needed integer,
+  low_stock integer,
+  orders_today integer
+) AS $$
+BEGIN
+  SELECT COUNT(*)
+    INTO upcoming_appointments
+    FROM bookings
+    WHERE appointment_date >= NOW()
+      AND appointment_date < NOW() + INTERVAL '7 days';
+
+  SELECT COUNT(*)
+    INTO product_usage_needed
+    FROM product_usage_sessions
+    WHERE completed = false;
+
+  SELECT COUNT(*)
+    INTO low_stock
+    FROM products
+    WHERE is_active = true
+      AND current_stock <= min_threshold;
+
+  SELECT COUNT(*)
+    INTO orders_today
+    FROM orders
+    WHERE created_at::date = CURRENT_DATE;
+
+  RETURN NEXT;
+END;
+$$ LANGUAGE plpgsql;

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,0 +1,91 @@
+import { useState, useEffect } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+
+export default function Dashboard() {
+  const [metrics, setMetrics] = useState(null)
+  const [branding, setBranding] = useState(null)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const bRes = await fetch('/api/get-branding')
+        if (bRes.ok) {
+          const data = await bRes.json()
+          setBranding(data.branding)
+        }
+
+        const mRes = await fetch('/api/get-dashboard-metrics')
+        if (mRes.ok) {
+          const data = await mRes.json()
+          setMetrics(data.metrics)
+        }
+      } catch (err) {
+        console.error('Dashboard load error', err)
+      }
+    }
+    load()
+  }, [])
+
+  const upcomingCount = metrics?.upcoming_appointments || 0
+  const ordersToday = metrics?.orders_today || 0
+  const productUsageNeeded = metrics?.product_usage_needed || 0
+  const lowStock = metrics?.low_stock || 0
+
+  return (
+    <>
+      <Head>
+        <title>Dashboard - Keeping It Cute Salon</title>
+      </Head>
+      <div style={{ fontFamily: 'Arial, sans-serif', padding: '20px' }}>
+        {/* Hero Header */}
+        <div style={{ textAlign: 'center', marginBottom: '30px' }}>
+          {branding?.logo_url && (
+            <img src={branding.logo_url} alt="Salon Logo" style={{ height: '80px' }} />
+          )}
+          <h1 style={{ margin: '10px 0' }}>Welcome Back!</h1>
+          <p>{new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}</p>
+        </div>
+
+        {/* Metrics */}
+        <h2 style={{ marginBottom: '15px' }}>Metrics at a Glance</h2>
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+          gap: '20px',
+          marginBottom: '30px'
+        }}>
+          <div style={{ background: '#fff', padding: '20px', borderRadius: '8px', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', textAlign: 'center' }}>
+            <h3>Upcoming Appointments</h3>
+            <p style={{ fontSize: '2em', margin: 0 }}>{upcomingCount}</p>
+          </div>
+          <div style={{ background: '#fff', padding: '20px', borderRadius: '8px', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', textAlign: 'center' }}>
+            <h3>Product Usage Forms Needed</h3>
+            <p style={{ fontSize: '2em', margin: 0 }}>{productUsageNeeded}</p>
+          </div>
+          <div style={{ background: '#fff', padding: '20px', borderRadius: '8px', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', textAlign: 'center' }}>
+            <h3>Low Stock</h3>
+            <p style={{ fontSize: '2em', margin: 0 }}>{lowStock}</p>
+          </div>
+          <div style={{ background: '#fff', padding: '20px', borderRadius: '8px', boxShadow: '0 1px 4px rgba(0,0,0,0.1)', textAlign: 'center' }}>
+            <h3>Orders Today</h3>
+            <p style={{ fontSize: '2em', margin: 0 }}>{ordersToday}</p>
+          </div>
+        </div>
+
+        {/* Alerts */}
+        <div style={{ background: '#fff3cd', padding: '20px', borderRadius: '8px', marginBottom: '30px', border: '1px solid #ffeeba' }}>
+          You have {productUsageNeeded} appointments that require product usage logs.
+        </div>
+
+        {/* Quick Links */}
+        <h3>Quick Links</h3>
+        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+          <Link href="/product-usage-dashboard" style={{ padding: '10px 15px', background: '#e0cdbb', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>Log Product Usage</Link>
+          <Link href="/staff?tab=appointments" style={{ padding: '10px 15px', background: '#667eea', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>View All Appointments</Link>
+          <Link href="/alerts" style={{ padding: '10px 15px', background: '#d32f2f', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>Restock Inventory</Link>
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple dashboard page showing counts for appointments, orders, and low stock
- provide SQL function for metrics and API endpoint `get-dashboard-metrics`
- update dashboard page to use aggregated metrics

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696dea8444832aa3ffb74cc11ab841