### PR TITLE
Add Wix OAuth login flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ SUPABASE_RECEIPTS_BUCKET=product-usage-images
 # Optional: Webhook Security
 WIX_WEBHOOK_SECRET=your-wix-webhook-secret-for-verification
 WIX_API_TOKEN=your-wix-api-token
+WIX_CLIENT_ID=your-wix-client-id
+WIX_CLIENT_SECRET=your-wix-client-secret
+NEXT_PUBLIC_WIX_CLIENT_ID=your-wix-client-id
+NEXT_PUBLIC_WIX_REDIRECT_URI=http://localhost:3000/api/wix-oauth-callback
 
 # Optional: Email Notifications
 NOTIFICATION_EMAIL=your-email@keepingitcute.com

--- a/README.md
+++ b/README.md
@@ -280,6 +280,14 @@ psql $SUPABASE_URL < migrations/20240102_add_profiles_table.sql
 Use the `/login` and `/signup` pages to authenticate.
 After login, requests include a `Bearer` token from the Supabase session in the `Authorization` header.
 
+Alternatively you can enable Wix OAuth. Set the `WIX_CLIENT_ID`,
+`WIX_CLIENT_SECRET`, `NEXT_PUBLIC_WIX_CLIENT_ID`, and
+`NEXT_PUBLIC_WIX_REDIRECT_URI` environment variables. The login page includes a
+"Login with Wix" button that sends users to Wix for authorization. The callback
+route `/api/wix-oauth-callback` exchanges the code for an access token and stores
+it in a `wix_token` cookie. Pages like `/staff` use the `useRequireWixAuth` hook
+to redirect to `/login` if the token is missing.
+
 ### Error handling
 
 Unexpected client errors are captured by a React error boundary defined in `pages/_app.js`. When an exception occurs, the boundary renders a simple message instead of leaving the page blank.

--- a/api/wix-oauth-callback.js
+++ b/api/wix-oauth-callback.js
@@ -1,0 +1,49 @@
+import cookie from 'cookie'
+
+export default async function handler(req, res) {
+  const { code } = req.query
+
+  if (!code) {
+    return res.status(400).json({ error: 'Missing authorization code' })
+  }
+
+  const clientId = process.env.WIX_CLIENT_ID
+  const clientSecret = process.env.WIX_CLIENT_SECRET
+  const redirectUri = process.env.NEXT_PUBLIC_WIX_REDIRECT_URI
+
+  try {
+    const tokenRes = await fetch('https://www.wix.com/oauth/access', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: redirectUri
+      })
+    })
+
+    if (!tokenRes.ok) {
+      const err = await tokenRes.text()
+      return res.status(500).json({ error: 'Failed to fetch access token', details: err })
+    }
+
+    const tokenData = await tokenRes.json()
+    const token = tokenData.access_token
+
+    res.setHeader('Set-Cookie', cookie.serialize('wix_token', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/'
+    }))
+
+    res.redirect('/staff')
+  } catch (error) {
+    console.error('Wix OAuth Error:', error)
+    res.status(500).json({ error: 'OAuth error', details: error.message })
+  }
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -25,6 +25,12 @@ export default function Login() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
 
+  const wixClientId = process.env.NEXT_PUBLIC_WIX_CLIENT_ID
+  const redirect = encodeURIComponent(
+    process.env.NEXT_PUBLIC_WIX_REDIRECT_URI || ''
+  )
+  const wixAuthUrl = `https://www.wix.com/installer/install?token=&appId=${wixClientId}&redirectUrl=${redirect}`
+
   const handleSubmit = async (e) => {
     e.preventDefault()
     setLoading(true)
@@ -119,6 +125,23 @@ export default function Login() {
           >
             {loading ? 'Signing in...' : 'Login'}
           </button>
+          <a href={wixAuthUrl} style={{ textDecoration: 'none' }}>
+            <button
+              type="button"
+              style={{
+                width: '100%',
+                marginTop: '10px',
+                padding: '10px',
+                backgroundColor: '#6b8ec4',
+                color: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer'
+              }}
+            >
+              Login with Wix
+            </button>
+          </a>
           <p style={{ marginTop: '15px', textAlign: 'center' }}>
             No account? <a href="/signup">Sign up</a>
           </p>

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import slugify from '../utils/slugify'
+import useRequireWixAuth from '../utils/useRequireWixAuth'
 
 // Determine if a product image URL from Wix is unusable in the browser
 const isWixImage = (url) => url && url.startsWith('wix:image://')
@@ -18,6 +19,7 @@ import CalendarView from '../components/CalendarView'
 
 export default function StaffPortal() {
   const router = useRouter()
+  useRequireWixAuth()
   const [products, setProducts] = useState([])
   const [madamGlamCount, setMadamGlamCount] = useState(0)
   const [services, setServices] = useState([])

--- a/utils/useRequireWixAuth.js
+++ b/utils/useRequireWixAuth.js
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function useRequireWixAuth() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const match = document.cookie.match(/(?:^|; )wix_token=([^;]*)/)
+    const token = match ? decodeURIComponent(match[1]) : null
+    if (!token) {
+      router.replace('/login')
+    }
+  }, [router])
+}


### PR DESCRIPTION
## Summary
- enable Wix OAuth authentication in login page
- create `/api/wix-oauth-callback` API route
- require Wix auth cookie on staff portal
- add hook `useRequireWixAuth`
- document Wix OAuth setup in README
- extend `.env.example` with Wix OAuth vars

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686974a8ec78832a9b09a6130520d4c9