### PR TITLE
Switch staff portal to Supabase auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ npm run dev
 ```
 
 Open `http://localhost:3000/signup` to create your first user (or `/login` if an account already exists). Successful authentication redirects to `/staff`.
+Your staff portal uses Supabase-only login. Staff members visit `/login` and sign in with the email and password you created for them in the Supabase dashboard. After logging in they land on `/staff` and all API requests are authorized using their Supabase session.
 
 ## 📷 Service Images
 
@@ -280,13 +281,11 @@ psql $SUPABASE_URL < migrations/20240102_add_profiles_table.sql
 Use the `/login` and `/signup` pages to authenticate.
 After login, requests include a `Bearer` token from the Supabase session in the `Authorization` header.
 
-Alternatively you can enable Wix OAuth. Set the `WIX_CLIENT_ID`,
-`WIX_CLIENT_SECRET`, `NEXT_PUBLIC_WIX_CLIENT_ID`, and
-`NEXT_PUBLIC_WIX_REDIRECT_URI` environment variables. The login page includes a
-"Login with Wix" button that sends users to Wix for authorization. The callback
-route `/api/wix-oauth-callback` exchanges the code for an access token and stores
-it in a `wix_token` cookie. Pages like `/staff` use the `useRequireWixAuth` hook
-to redirect to `/login` if the token is missing.
+This project previously supported Wix OAuth, but the staff portal now relies
+solely on Supabase authentication. Staff members sign in with the credentials
+you create for them in Supabase. After logging in they are redirected to
+`/staff`, and all requests include the Supabase session token in the
+`Authorization` header.
 
 ### Error handling
 

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+export async function middleware(req) {
+  const { pathname } = req.nextUrl
+
+  if (!pathname.startsWith('/api')) {
+    return NextResponse.next()
+  }
+
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const token = authHeader.slice(7)
+  const supabaseUrl = process.env.SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceKey) {
+    return new NextResponse('Server misconfiguration', { status: 500 })
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey)
+  const { data, error } = await supabase.auth.getUser(token)
+
+  if (error || !data?.user) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  return NextResponse.next()
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -25,11 +25,6 @@ export default function Login() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
 
-  const wixClientId = process.env.NEXT_PUBLIC_WIX_CLIENT_ID
-  const redirect = encodeURIComponent(
-    process.env.NEXT_PUBLIC_WIX_REDIRECT_URI || ''
-  )
-  const wixAuthUrl = `https://www.wix.com/installer/install?token=&appId=${wixClientId}&redirectUrl=${redirect}`
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -125,23 +120,6 @@ export default function Login() {
           >
             {loading ? 'Signing in...' : 'Login'}
           </button>
-          <a href={wixAuthUrl} style={{ textDecoration: 'none' }}>
-            <button
-              type="button"
-              style={{
-                width: '100%',
-                marginTop: '10px',
-                padding: '10px',
-                backgroundColor: '#6b8ec4',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer'
-              }}
-            >
-              Login with Wix
-            </button>
-          </a>
           <p style={{ marginTop: '15px', textAlign: 'center' }}>
             No account? <a href="/signup">Sign up</a>
           </p>

--- a/pages/staff-chat.js
+++ b/pages/staff-chat.js
@@ -2,8 +2,10 @@ import { useState, useEffect, useRef } from 'react'
 import Head from 'next/head'
 import { createClient } from '@supabase/supabase-js'
 import StaffNavBar from '../components/StaffNavBar'
+import useRequireSupabaseAuth from '../utils/useRequireSupabaseAuth'
 
 export default function StaffChat() {
+  useRequireSupabaseAuth()
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   if (!supabaseUrl || !supabaseAnonKey) {

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import slugify from '../utils/slugify'
-import useRequireWixAuth from '../utils/useRequireWixAuth'
+import useRequireSupabaseAuth from '../utils/useRequireSupabaseAuth'
 
 // Determine if a product image URL from Wix is unusable in the browser
 const isWixImage = (url) => url && url.startsWith('wix:image://')
@@ -19,7 +19,7 @@ import CalendarView from '../components/CalendarView'
 
 export default function StaffPortal() {
   const router = useRouter()
-  useRequireWixAuth()
+  useRequireSupabaseAuth()
   const [products, setProducts] = useState([])
   const [madamGlamCount, setMadamGlamCount] = useState(0)
   const [services, setServices] = useState([])

--- a/utils/useRequireSupabaseAuth.js
+++ b/utils/useRequireSupabaseAuth.js
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { createClient } from '@supabase/supabase-js'
+
+export default function useRequireSupabaseAuth() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    if (!supabaseUrl || !supabaseAnonKey) {
+      router.replace('/login')
+      return
+    }
+    const supabase = createClient(supabaseUrl, supabaseAnonKey)
+    supabase.auth.getSession().then(({ data }) => {
+      if (!data.session) {
+        router.replace('/login')
+      }
+    })
+  }, [router])
+}


### PR DESCRIPTION
## Summary
- add a middleware that checks Supabase tokens on all API routes
- remove the Wix OAuth button from the login page
- add a React hook to enforce Supabase authentication on protected pages
- update staff portal and chat pages to use the new hook
- document Supabase-only login in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bcc6d29c832a8b40fdb77b7f76fd