### PR TITLE
Handle Supabase invite token

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,11 @@ you create for them in Supabase. After logging in they are redirected to
 `/staff`, and all requests include the Supabase session token in the
 `Authorization` header.
 
+When a staff member uses a Supabase invite or magic link, the URL includes
+`#access_token=...`. The app now detects this fragment in `pages/_app.js`, calls
+`supabase.auth.getSessionFromUrl()` to store the session, and then redirects to
+`/staff` automatically.
+
 ### Error handling
 
 Unexpected client errors are captured by a React error boundary defined in `pages/_app.js`. When an exception occurs, the boundary renders a simple message instead of leaving the page blank.

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,9 +1,33 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { createClient } from '@supabase/supabase-js'
 import ErrorBoundary from '../components/ErrorBoundary'
 import Layout from '../components/Layout'
 import '../styles/globals.css'
 
 export default function MyApp({ Component, pageProps }) {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const hash = window.location.hash
+    if (!hash || !hash.includes('access_token')) return
+
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    if (!url || !key) return
+
+    const supabase = createClient(url, key)
+    supabase.auth
+      .getSessionFromUrl()
+      .then(({ data }) => {
+        if (data?.session) {
+          router.replace('/staff')
+        }
+      })
+      .catch(() => {})
+  }, [router])
+
   return (
     <ErrorBoundary>
       <Layout>

--- a/utils/useRequireSupabaseAuth.js
+++ b/utils/useRequireSupabaseAuth.js
@@ -12,11 +12,28 @@ export default function useRequireSupabaseAuth() {
       router.replace('/login')
       return
     }
+
     const supabase = createClient(supabaseUrl, supabaseAnonKey)
-    supabase.auth.getSession().then(({ data }) => {
+
+    async function checkSession() {
+      if (typeof window !== 'undefined' && window.location.hash.includes('access_token')) {
+        try {
+          const { data } = await supabase.auth.getSessionFromUrl()
+          if (data?.session) {
+            router.replace('/staff')
+            return
+          }
+        } catch (e) {
+          // ignore parsing errors
+        }
+      }
+
+      const { data } = await supabase.auth.getSession()
       if (!data.session) {
         router.replace('/login')
       }
-    })
+    }
+
+    checkSession()
   }, [router])
 }


### PR DESCRIPTION
## Summary
- handle magic link fragments in `_app.js`
- parse invite token in `useRequireSupabaseAuth` hook
- document automatic invite handling in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c648d5d4832ab17355e906609415