### PR TITLE
Improve auth error handling

### DIFF
--- a/tests/fetchWithAuth.test.js
+++ b/tests/fetchWithAuth.test.js
@@ -1,0 +1,39 @@
+beforeEach(() => {
+  jest.resetModules()
+  global.fetch = jest.fn(() => Promise.resolve({ status: 200 }))
+  global.window = { location: { href: '' } }
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon'
+})
+
+afterEach(() => {
+  delete global.fetch
+  delete global.window
+  delete process.env.NEXT_PUBLIC_SUPABASE_URL
+  delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+})
+
+test('includes Authorization header when session token available', async () => {
+  jest.doMock('@supabase/supabase-js', () => ({
+    createClient: () => ({
+      auth: {
+        getSession: jest.fn().mockResolvedValue({ data: { session: { access_token: 'token' } } })
+      }
+    })
+  }))
+  const { fetchWithAuth } = await import('../utils/api')
+  await fetchWithAuth('/api/test')
+  expect(fetch).toHaveBeenCalledWith('/api/test', expect.objectContaining({
+    headers: expect.objectContaining({ Authorization: 'Bearer token' })
+  }))
+})
+
+test('redirects to login on 401 response', async () => {
+  global.fetch.mockResolvedValue({ status: 401 })
+  jest.doMock('@supabase/supabase-js', () => ({
+    createClient: () => ({ auth: { getSession: jest.fn().mockResolvedValue({ data: { session: null } }) } })
+  }))
+  const { fetchWithAuth } = await import('../utils/api')
+  await fetchWithAuth('/api/test')
+  expect(global.window.location.href).toBe('/login')
+})

--- a/utils/api.js
+++ b/utils/api.js
@@ -17,5 +17,9 @@ export async function fetchWithAuth(url, options = {}) {
       opts.headers['Authorization'] = `Bearer ${token}`
     }
   }
-  return fetch(url, opts)
+  const res = await fetch(url, opts)
+  if (res.status === 401 && typeof window !== 'undefined') {
+    window.location.href = '/login'
+  }
+  return res
 }


### PR DESCRIPTION
## Summary
- redirect to login when fetch requests are unauthorized
- test new fetchWithAuth behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d5e8cbb0832ab6a2f338deed6969