### PR TITLE
Add Chat link to navigation

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -46,6 +46,9 @@ export default function NavBar() {
         <Link href="/customers" className={styles.tab}>
           👥 Contacts
         </Link>
+        <Link href="/staff-chat" className={styles.tab}>
+          💬 Chat
+        </Link>
         <div className={styles.tools}>
           <button
             className={styles.tab}


### PR DESCRIPTION
## Summary
- expose staff chat from the main navigation bar

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d9161bf8832abfbeb6d604286aa7