### PR TITLE
Allow admin metrics access

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ curl '/api/get-customers?search=jane'
 Create a function in Supabase that aggregates the numbers used on the business dashboard:
 
 ```sql
--- migrations/20240916_update_dashboard_metrics_for_staff.sql
+-- migrations/20240917_allow_null_staff_in_dashboard_metrics.sql
 CREATE OR REPLACE FUNCTION dashboard_metrics(p_staff_id uuid)
 RETURNS TABLE(
   upcoming_appointments integer,
@@ -86,17 +86,17 @@ BEGIN
   RETURN QUERY
     SELECT
       (SELECT COUNT(*) FROM bookings
-         WHERE staff_id = p_staff_id
+         WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
            AND appointment_date >= NOW()
            AND appointment_date < NOW() + INTERVAL '7 days'),
       (SELECT COUNT(*) FROM product_usage_sessions
-         WHERE staff_id = p_staff_id
+         WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
            AND completed = false),
       (SELECT COUNT(*) FROM products
          WHERE is_active = true
            AND current_stock <= min_threshold),
       (SELECT COUNT(*) FROM orders
-         WHERE staff_id = p_staff_id
+         WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
            AND created_at::date = CURRENT_DATE);
 END;
 $$ LANGUAGE plpgsql STABLE;

--- a/api/get-dashboard-metrics.js
+++ b/api/get-dashboard-metrics.js
@@ -24,7 +24,12 @@ export default async function handler(req, res) {
     const user = await requireAuth(req, res)
     if (!user) return
 
-    const staffId = req.query.staff_id || user.id
+    let staffId = req.query.staff_id
+    if (staffId === undefined) {
+      staffId = user.id
+    } else if (staffId === '' || staffId === 'null') {
+      staffId = null
+    }
     const { data, error } = await supabase.rpc('dashboard_metrics', { p_staff_id: staffId })
     if (error) {
       throw error

--- a/migrations/20240917_allow_null_staff_in_dashboard_metrics.sql
+++ b/migrations/20240917_allow_null_staff_in_dashboard_metrics.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION dashboard_metrics(p_staff_id uuid)
+RETURNS TABLE(
+  upcoming_appointments integer,
+  product_usage_needed integer,
+  low_stock integer,
+  orders_today integer
+) AS $$
+BEGIN
+  RETURN QUERY
+    SELECT
+      (SELECT COUNT(*) FROM bookings
+         WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
+           AND appointment_date >= NOW()
+           AND appointment_date < NOW() + INTERVAL '7 days'),
+      (SELECT COUNT(*) FROM product_usage_sessions
+         WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
+           AND completed = false),
+      (SELECT COUNT(*) FROM products
+         WHERE is_active = true
+           AND current_stock <= min_threshold),
+      (SELECT COUNT(*) FROM orders
+         WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
+           AND created_at::date = CURRENT_DATE);
+END;
+$$ LANGUAGE plpgsql STABLE;


### PR DESCRIPTION
## Summary
- add a migration to allow passing `NULL` to `dashboard_metrics`
- document new metrics function
- handle `staff_id` query value of `null` in the metrics API

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7a50cb4c832aad04793fef805e05