### PR TITLE
Add purchase order CRUD API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 | `sessions` | Website analytics | Visitor behavior, engagement metrics |
 | `webhook_logs` | System monitoring | All webhook events and debugging |
 | `staff_chat_messages` | Internal staff chat | Message content and timestamps |
+| `purchase_orders` | Supply ordering | Vendor info, totals, status |
+| `purchase_order_items` | Items on a purchase order | Product ID, quantity, cost |
 
 ## 🔗 API Endpoints
 
@@ -58,6 +60,14 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 - `POST /api/create-checkout` - Generate a Wix checkout session for payments
 - `GET /api/staff-chat` - Retrieve recent staff chat messages
 - `POST /api/staff-chat` - Post a new staff chat message
+- `GET /api/purchase-orders` - Retrieve purchase orders
+- `POST /api/purchase-orders` - Create a new purchase order
+- `PUT /api/purchase-orders` - Update a purchase order
+- `DELETE /api/purchase-orders` - Remove a purchase order
+- `GET /api/purchase-order-items` - Retrieve items for a purchase order
+- `POST /api/purchase-order-items` - Add an item to a purchase order
+- `PUT /api/purchase-order-items` - Update a purchase order item
+- `DELETE /api/purchase-order-items` - Delete a purchase order item
 
 Example usage:
 
@@ -67,6 +77,11 @@ curl '/api/get-orders?limit=10'
 
 # Search for customers by name
 curl '/api/get-customers?search=jane'
+
+# Create a purchase order
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"vendor_id":"123","order_date":"2024-01-01"}' \
+  /api/purchase-orders
 ```
 
 ### Dashboard Metrics

--- a/api/purchase-order-items.js
+++ b/api/purchase-order-items.js
@@ -1,0 +1,118 @@
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, ['GET', 'POST', 'PUT', 'DELETE'])
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const { id, purchase_order_id, limit = '50' } = req.query
+      let query = supabase
+        .from('purchase_order_items')
+        .select('*')
+
+      if (id) {
+        query = query.eq('id', id).single()
+      } else {
+        query = query.order('created_at', { ascending: false }).limit(parseInt(limit))
+        if (purchase_order_id) query = query.eq('purchase_order_id', purchase_order_id)
+      }
+
+      const { data, error } = await query
+
+      if (error) {
+        console.error('❌ Purchase order items fetch error:', error)
+        return res.status(500).json({ error: 'Failed to fetch purchase order items', details: error.message })
+      }
+
+      const items = id ? (data ? [data] : []) : data || []
+      return res.status(200).json({ success: true, purchase_order_items: items, count: items.length })
+    } catch (err) {
+      console.error('❌ Get purchase order items error:', err)
+      return res.status(500).json({ error: 'Unexpected error', details: err.message })
+    }
+  }
+
+  if (req.method === 'POST') {
+    try {
+      const item = req.body || {}
+      const { data, error } = await supabase
+        .from('purchase_order_items')
+        .insert(item)
+        .select()
+        .single()
+
+      if (error) {
+        console.error('❌ Purchase order item insert error:', error)
+        return res.status(500).json({ error: 'Failed to create purchase order item', details: error.message })
+      }
+
+      return res.status(200).json({ purchase_order_item: data })
+    } catch (err) {
+      console.error('❌ Purchase order item insert exception:', err)
+      return res.status(500).json({ error: 'Unexpected error', details: err.message })
+    }
+  }
+
+  if (req.method === 'PUT') {
+    try {
+      const { id, ...updates } = req.body || {}
+      if (!id) {
+        return res.status(400).json({ error: 'id is required' })
+      }
+
+      const { data, error } = await supabase
+        .from('purchase_order_items')
+        .update({ ...updates, updated_at: new Date().toISOString() })
+        .eq('id', id)
+        .select()
+        .single()
+
+      if (error) {
+        console.error('❌ Purchase order item update error:', error)
+        return res.status(500).json({ error: 'Failed to update purchase order item', details: error.message })
+      }
+
+      return res.status(200).json({ purchase_order_item: data })
+    } catch (err) {
+      console.error('❌ Purchase order item update exception:', err)
+      return res.status(500).json({ error: 'Unexpected error', details: err.message })
+    }
+  }
+
+  if (req.method === 'DELETE') {
+    try {
+      const { id } = req.query
+      if (!id) {
+        return res.status(400).json({ error: 'id query parameter is required' })
+      }
+
+      const { error } = await supabase
+        .from('purchase_order_items')
+        .delete()
+        .eq('id', id)
+
+      if (error) {
+        console.error('❌ Purchase order item delete error:', error)
+        return res.status(500).json({ error: 'Failed to delete purchase order item', details: error.message })
+      }
+
+      return res.status(200).json({ success: true })
+    } catch (err) {
+      console.error('❌ Purchase order item delete exception:', err)
+      return res.status(500).json({ error: 'Unexpected error', details: err.message })
+    }
+  }
+
+  res.status(405).json({ error: 'Method Not Allowed' })
+}

--- a/api/purchase-orders.js
+++ b/api/purchase-orders.js
@@ -1,0 +1,118 @@
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, ['GET', 'POST', 'PUT', 'DELETE'])
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const { id, vendor_id, limit = '50' } = req.query
+      let query = supabase
+        .from('purchase_orders')
+        .select('*')
+
+      if (id) {
+        query = query.eq('id', id).single()
+      } else {
+        query = query.order('created_at', { ascending: false }).limit(parseInt(limit))
+        if (vendor_id) query = query.eq('vendor_id', vendor_id)
+      }
+
+      const { data, error } = await query
+
+      if (error) {
+        console.error('❌ Purchase orders fetch error:', error)
+        return res.status(500).json({ error: 'Failed to fetch purchase orders', details: error.message })
+      }
+
+      const orders = id ? (data ? [data] : []) : data || []
+      return res.status(200).json({ success: true, purchase_orders: orders, count: orders.length })
+    } catch (err) {
+      console.error('❌ Get purchase orders error:', err)
+      return res.status(500).json({ error: 'Unexpected error', details: err.message })
+    }
+  }
+
+  if (req.method === 'POST') {
+    try {
+      const order = req.body || {}
+      const { data, error } = await supabase
+        .from('purchase_orders')
+        .insert(order)
+        .select()
+        .single()
+
+      if (error) {
+        console.error('❌ Purchase order insert error:', error)
+        return res.status(500).json({ error: 'Failed to create purchase order', details: error.message })
+      }
+
+      return res.status(200).json({ purchase_order: data })
+    } catch (err) {
+      console.error('❌ Purchase order insert exception:', err)
+      return res.status(500).json({ error: 'Unexpected error', details: err.message })
+    }
+  }
+
+  if (req.method === 'PUT') {
+    try {
+      const { id, ...updates } = req.body || {}
+      if (!id) {
+        return res.status(400).json({ error: 'id is required' })
+      }
+
+      const { data, error } = await supabase
+        .from('purchase_orders')
+        .update({ ...updates, updated_at: new Date().toISOString() })
+        .eq('id', id)
+        .select()
+        .single()
+
+      if (error) {
+        console.error('❌ Purchase order update error:', error)
+        return res.status(500).json({ error: 'Failed to update purchase order', details: error.message })
+      }
+
+      return res.status(200).json({ purchase_order: data })
+    } catch (err) {
+      console.error('❌ Purchase order update exception:', err)
+      return res.status(500).json({ error: 'Unexpected error', details: err.message })
+    }
+  }
+
+  if (req.method === 'DELETE') {
+    try {
+      const { id } = req.query
+      if (!id) {
+        return res.status(400).json({ error: 'id query parameter is required' })
+      }
+
+      const { error } = await supabase
+        .from('purchase_orders')
+        .delete()
+        .eq('id', id)
+
+      if (error) {
+        console.error('❌ Purchase order delete error:', error)
+        return res.status(500).json({ error: 'Failed to delete purchase order', details: error.message })
+      }
+
+      return res.status(200).json({ success: true })
+    } catch (err) {
+      console.error('❌ Purchase order delete exception:', err)
+      return res.status(500).json({ error: 'Unexpected error', details: err.message })
+    }
+  }
+
+  res.status(405).json({ error: 'Method Not Allowed' })
+}


### PR DESCRIPTION
## Summary
- implement `purchase-orders` and `purchase-order-items` API handlers
- connect handlers to Supabase for CRUD support
- document new endpoints and example usage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a479ac4832abdab518ee78b45fb