### PR TITLE
Add staff revenue logging and stock adjustment endpoint

### DIFF
--- a/api/payment-approved.js
+++ b/api/payment-approved.js
@@ -98,6 +98,18 @@ export default async function handler(req, res) {
             }
           });
 
+        // Record revenue for the staff member if available
+        if (appointment.staff_id) {
+          await supabase
+            .from('staff_revenue')
+            .insert({
+              staff_id: appointment.staff_id,
+              appointment_id: appointment.id,
+              revenue_amount: payment.amount,
+              revenue_date: new Date().toISOString().split('T')[0]
+            });
+        }
+
         // Send confirmation email could go here
         console.log('📧 Payment confirmation ready for:', appointment.customers?.email);
       }

--- a/api/record-stock-adjustment.js
+++ b/api/record-stock-adjustment.js
@@ -1,0 +1,57 @@
+// api/record-stock-adjustment.js - Log manual stock corrections
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const { product_id, quantity_change, reason, staff_id } = req.body || {}
+
+    if (!product_id || typeof quantity_change !== 'number' || !reason) {
+      return res.status(400).json({ error: 'Missing required fields' })
+    }
+
+    const { data: adjustment, error } = await supabase
+      .from('stock_adjustments')
+      .insert({ product_id, quantity_change, reason, staff_id })
+      .select()
+      .single()
+
+    if (error) {
+      console.error('❌ Stock adjustment error:', error)
+      return res.status(500).json({
+        error: 'Failed to record stock adjustment',
+        details: error.message
+      })
+    }
+
+    const { data: product, error: fetchError } = await supabase
+      .from('products')
+      .select('current_stock')
+      .eq('id', product_id)
+      .single()
+
+    if (!fetchError && product) {
+      await supabase
+        .from('products')
+        .update({ current_stock: product.current_stock + quantity_change })
+        .eq('id', product_id)
+    }
+
+    res.status(200).json({
+      success: true,
+      adjustment,
+      timestamp: new Date().toISOString()
+    })
+  } catch (err) {
+    console.error('❌ Stock adjustment exception:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/tests/record-stock-adjustment.test.js
+++ b/tests/record-stock-adjustment.test.js
@@ -1,0 +1,63 @@
+// tests for api/record-stock-adjustment.js
+const createQuery = (result) => {
+  const promise = Promise.resolve(result)
+  promise.insert = jest.fn(() => promise)
+  promise.select = jest.fn(() => promise)
+  promise.single = jest.fn(() => promise)
+  promise.update = jest.fn(() => promise)
+  promise.eq = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this }),
+  json: jest.fn(function(){ return this })
+})
+
+describe('record-stock-adjustment handler', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    process.env.SUPABASE_URL = 'http://example.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+  })
+
+  test('returns 405 on non-POST requests', async () => {
+    const from = jest.fn(() => createQuery({ data: [], error: null }))
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+
+    const { default: handler } = await import('../api/record-stock-adjustment.js')
+
+    const req = { method: 'GET' }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('inserts adjustment and updates product', async () => {
+    const insertQuery = createQuery({ data: { id: 1 }, error: null })
+    const selectQuery = createQuery({ data: { current_stock: 5 }, error: null })
+
+    const from = jest.fn((table) => {
+      if (table === 'stock_adjustments') return insertQuery
+      if (table === 'products') return selectQuery
+    })
+
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+
+    const { default: handler } = await import('../api/record-stock-adjustment.js')
+
+    const req = { method: 'POST', body: { product_id: 'p1', quantity_change: 2, reason: 'fix', staff_id: 's1' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('stock_adjustments')
+    expect(insertQuery.insert).toHaveBeenCalledWith({ product_id: 'p1', quantity_change: 2, reason: 'fix', staff_id: 's1' })
+    expect(from).toHaveBeenCalledWith('products')
+    expect(selectQuery.select).toHaveBeenCalledWith('current_stock')
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+})


### PR DESCRIPTION
## Summary
- track staff revenue in `payment-approved` webhook
- add `record-stock-adjustment` endpoint for manual inventory corrections
- test stock adjustment endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b14bf5920832aa265192a0753256c