### PR TITLE
Update staff portal header background color

### DIFF
--- a/pages/staff.js
+++ b/pages/staff.js
@@ -444,8 +444,8 @@ export default function StaffPortal() {
 
       <div style={{ fontFamily: 'Arial, sans-serif', backgroundColor: '#f8f9fa', minHeight: '100vh' }}>
         {/* Header with Logo */}
-        <header style={{ 
-          background: `linear-gradient(135deg, ${branding?.primary_color || '#e0cdbb'} 0%, ${branding?.secondary_color || '#eee4da'} 100%)`,
+        <header style={{
+          background: '#F7F2ED',
           padding: '30px 20px',
           color: 'white',
           textAlign: 'center',


### PR DESCRIPTION
## Summary
- adjust staff portal header style to use a solid background

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873475515f8832a9eed9769f7257322