### PR TITLE
Add staff profile page and navbar user info

### DIFF
--- a/api/profile.js
+++ b/api/profile.js
@@ -1,0 +1,53 @@
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
+import requireAuth from '../utils/requireAuth'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, ['GET', 'POST'])
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  const user = await requireAuth(req, res)
+  if (!user) return
+
+  if (req.method === 'GET') {
+    const { data, error } = await supabase
+      .from('staff_profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single()
+
+    if (error && error.code !== 'PGRST116') {
+      return res.status(500).json({ error: 'Failed to load profile', details: error.message })
+    }
+
+    res.status(200).json({ profile: { email: user.email, ...(data || {}) } })
+    return
+  }
+
+  if (req.method === 'POST') {
+    const { full_name, phone, address, gender } = req.body || {}
+    const { data, error } = await supabase
+      .from('staff_profiles')
+      .upsert({ id: user.id, full_name, phone, address, gender, updated_at: new Date().toISOString() }, { onConflict: 'id' })
+      .select()
+      .single()
+
+    if (error) {
+      return res.status(500).json({ error: 'Failed to save profile', details: error.message })
+    }
+
+    res.status(200).json({ profile: data })
+    return
+  }
+
+  res.status(405).json({ error: 'Method Not Allowed' })
+}

--- a/components/NavBar.module.css
+++ b/components/NavBar.module.css
@@ -82,6 +82,11 @@
   align-items: center;
 }
 
+.user {
+  font-weight: bold;
+  color: var(--color-soft-white);
+}
+
 .toggle {
   display: none;
   background: none;

--- a/migrations/20241006_create_staff_profiles_table.sql
+++ b/migrations/20241006_create_staff_profiles_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS staff_profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id),
+  full_name text,
+  phone text,
+  address text,
+  gender text,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- create `profile` API for retrieving and updating staff profile data
- add a new Profile page with fields for full name, address, phone, and gender
- display logged-in user info in the NavBar with Profile and Logout actions
- include migration for new `staff_profiles` table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68745f2a5998832aa9e443d162cb6e90