### PR TITLE
Add staff avatar upload

### DIFF
--- a/api/staff-chat.js
+++ b/api/staff-chat.js
@@ -1,6 +1,7 @@
 // api/staff-chat.js - Staff chat messages API
 import { createClient } from '@supabase/supabase-js'
 import { setCorsHeaders } from '../utils/cors'
+import requireAuth from '../utils/requireAuth'
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -37,14 +38,22 @@ export default async function handler(req, res) {
 
   if (req.method === 'POST') {
     try {
-      const { content, username } = req.body || {}
+      const user = await requireAuth(req, res)
+      if (!user) return
+
+      const { content, username, avatar_url } = req.body || {}
       if (!content) {
         return res.status(400).json({ error: 'Message content required' })
       }
 
       const { data, error } = await supabase
         .from('staff_chat_messages')
-        .insert({ content, username })
+        .insert({
+          content,
+          username,
+          user_id: user.id,
+          avatar_url
+        })
         .select()
         .single()
 

--- a/api/upload-staff-avatar.js
+++ b/api/upload-staff-avatar.js
@@ -1,0 +1,74 @@
+import formidable from 'formidable'
+import fs from 'fs'
+import path from 'path'
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
+import requireAuth from '../utils/requireAuth'
+
+export const config = {
+  api: { bodyParser: false }
+}
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'POST')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  const user = await requireAuth(req, res)
+  if (!user) return
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const form = formidable({ maxFileSize: 5 * 1024 * 1024, keepExtensions: true })
+  const data = await new Promise((resolve, reject) => {
+    form.parse(req, (err, fields, files) => {
+      if (err) reject(err)
+      else resolve({ fields, files })
+    })
+  }).catch(() => null)
+
+  if (!data) {
+    return res.status(400).json({ error: 'Invalid form data' })
+  }
+
+  const file = data.files.avatar || data.files.file || data.files.image
+  if (!file) {
+    return res.status(400).json({ error: 'No file uploaded' })
+  }
+
+  const bucket = process.env.SUPABASE_STORAGE_BUCKET || 'salon-images'
+  const ext = path.extname(file.originalFilename || '.jpg').toLowerCase()
+  const filePath = `avatars/${user.id}${ext}`
+  const buffer = fs.readFileSync(file.filepath)
+  const { error: uploadError } = await supabase.storage
+    .from(bucket)
+    .upload(filePath, buffer, { contentType: file.mimetype, upsert: true })
+  fs.unlinkSync(file.filepath)
+  if (uploadError) {
+    return res.status(500).json({ error: 'Failed to upload avatar' })
+  }
+
+  const { data: publicData } = supabase.storage.from(bucket).getPublicUrl(filePath)
+  const avatarUrl = publicData.publicUrl
+
+  const { data: profile, error } = await supabase
+    .from('staff_profiles')
+    .upsert({ id: user.id, avatar_url: avatarUrl, updated_at: new Date().toISOString() }, { onConflict: 'id' })
+    .select()
+    .single()
+  if (error) {
+    return res.status(500).json({ error: 'Failed to save profile' })
+  }
+
+  res.status(200).json({ profile })
+}

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -8,6 +8,7 @@ export default function NavBar() {
   const [open, setOpen] = useState(false)
   const [toolsOpen, setToolsOpen] = useState(false)
   const [user, setUser] = useState(null)
+  const [profile, setProfile] = useState(null)
   const router = useRouter()
 
   // Close menus on route change
@@ -35,6 +36,14 @@ export default function NavBar() {
       subscription.unsubscribe()
     }
   }, [])
+
+  useEffect(() => {
+    if (!user) return
+    fetch('/api/profile')
+      .then(res => res.ok ? res.json() : null)
+      .then(data => setProfile(data?.profile || null))
+      .catch(() => {})
+  }, [user])
 
   return (
     <nav className={styles.navbar}>
@@ -98,6 +107,11 @@ export default function NavBar() {
         <div className={styles.right}>
           {user && (
             <>
+              <img
+                src={profile?.avatar_url || '/images/avatar-placeholder.svg'}
+                alt="avatar"
+                className={styles.avatar}
+              />
               <span className={styles.user}>{user.email}</span>
               <Link href="/profile" className={styles.tab}>
                 Profile

--- a/components/NavBar.module.css
+++ b/components/NavBar.module.css
@@ -87,6 +87,12 @@
   color: var(--color-soft-white);
 }
 
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+
 .toggle {
   display: none;
   background: none;

--- a/migrations/20241007_add_avatar_url_to_staff_profiles.sql
+++ b/migrations/20241007_add_avatar_url_to_staff_profiles.sql
@@ -1,0 +1,2 @@
+ALTER TABLE staff_profiles
+ADD COLUMN IF NOT EXISTS avatar_url text;

--- a/migrations/20241008_add_user_and_avatar_to_staff_chat.sql
+++ b/migrations/20241008_add_user_and_avatar_to_staff_chat.sql
@@ -1,0 +1,3 @@
+ALTER TABLE staff_chat_messages
+ADD COLUMN IF NOT EXISTS user_id uuid REFERENCES auth.users(id),
+ADD COLUMN IF NOT EXISTS avatar_url text;

--- a/migrations/20241009_create_staff_chat_messages_table_if_missing.sql
+++ b/migrations/20241009_create_staff_chat_messages_table_if_missing.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS staff_chat_messages (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  username text,
+  content text NOT NULL,
+  created_at timestamptz DEFAULT now()
+);

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -7,6 +7,7 @@ export default function Profile() {
   useRequireSupabaseAuth()
   const [loading, setLoading] = useState(true)
   const [profile, setProfile] = useState(null)
+  const [avatarFile, setAvatarFile] = useState(null)
   const [form, setForm] = useState({ full_name: '', phone: '', address: '', gender: '' })
   const [message, setMessage] = useState('')
 
@@ -44,9 +45,25 @@ export default function Profile() {
     })
     if (res.ok) {
       setMessage('Profile saved')
+      if (avatarFile) await uploadAvatar()
     } else {
       const err = await res.json().catch(() => ({}))
       setMessage(err.error || 'Failed to save')
+    }
+  }
+
+  const uploadAvatar = async () => {
+    if (!avatarFile) return
+    const fd = new FormData()
+    fd.append('avatar', avatarFile)
+    const res = await fetchWithAuth('/api/upload-staff-avatar', {
+      method: 'POST',
+      body: fd
+    })
+    if (res.ok) {
+      const data = await res.json()
+      setProfile(data.profile)
+      setAvatarFile(null)
     }
   }
 
@@ -63,6 +80,10 @@ export default function Profile() {
         <h1>My Profile</h1>
         {message && <p>{message}</p>}
         <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <img src={profile?.avatar_url || '/images/avatar-placeholder.svg'} alt="avatar" style={{ width: '80px', height: '80px', borderRadius: '50%' }} />
+            <input type="file" accept="image/*" onChange={e => setAvatarFile(e.target.files[0])} />
+          </div>
           <label>
             Full Name
             <input type="text" name="full_name" value={form.full_name} onChange={handleChange} style={{ width: '100%', padding: '8px' }} />

--- a/pages/staff-chat.js
+++ b/pages/staff-chat.js
@@ -23,11 +23,16 @@ export default function StaffChat() {
   const [branding, setBranding] = useState(null)
   const [messages, setMessages] = useState([])
   const [newMessage, setNewMessage] = useState('')
+  const [profile, setProfile] = useState(null)
   const bottomRef = useRef(null)
 
   useEffect(() => {
     loadBranding()
     fetchMessages()
+    fetch('/api/profile')
+      .then(res => res.ok ? res.json() : null)
+      .then(data => setProfile(data?.profile || null))
+      .catch(() => {})
 
     const channel = supabase
       .channel('staff_chat')
@@ -75,7 +80,11 @@ export default function StaffChat() {
       await fetchWithAuth('/api/staff-chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: newMessage })
+        body: JSON.stringify({
+          content: newMessage,
+          username: profile?.full_name,
+          avatar_url: profile?.avatar_url
+        })
       })
       setNewMessage('')
     } catch (err) {
@@ -97,8 +106,11 @@ export default function StaffChat() {
           <h1 style={{ marginTop: 0 }}>💬 Staff Chat</h1>
           <div style={{ maxHeight: '60vh', overflowY: 'auto', marginBottom: '20px' }}>
             {messages.map(msg => (
-              <div key={msg.id} style={{ marginBottom: '10px' }}>
-                <strong>{msg.username || 'Staff'}:</strong> {msg.content}
+              <div key={msg.id} style={{ marginBottom: '10px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <img src={msg.avatar_url || '/images/avatar-placeholder.svg'} alt="avatar" style={{ width: '32px', height: '32px', borderRadius: '50%' }} />
+                <div>
+                  <strong>{msg.username || 'Staff'}:</strong> {msg.content}
+                </div>
               </div>
             ))}
             <div ref={bottomRef} />

--- a/public/images/avatar-placeholder.svg
+++ b/public/images/avatar-placeholder.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="20" r="12" fill="#ddd" />
+  <path d="M8 56c0-12.15 9.85-22 24-22s24 9.85 24 22H8z" fill="#ddd" />
+</svg>

--- a/tests/staff-chat.test.js
+++ b/tests/staff-chat.test.js
@@ -64,16 +64,22 @@ describe('staff-chat handler', () => {
     const from = jest.fn(() => query)
     jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'u1' })))
 
     const { default: handler } = await import('../api/staff-chat.js')
 
-    const req = { method: 'POST', body: { content: 'hi' } }
+    const req = { method: 'POST', body: { content: 'hi', username: 'me', avatar_url: 'a' } }
     const res = createRes()
 
     await handler(req, res)
 
     expect(from).toHaveBeenCalledWith('staff_chat_messages')
-    expect(query.insert).toHaveBeenCalledWith({ content: 'hi', username: undefined })
+    expect(query.insert).toHaveBeenCalledWith({
+      content: 'hi',
+      username: 'me',
+      user_id: 'u1',
+      avatar_url: 'a'
+    })
     expect(query.select).toHaveBeenCalled()
     expect(query.single).toHaveBeenCalled()
     const response = res.json.mock.calls[0][0]


### PR DESCRIPTION
## Summary
- let staff upload profile avatars
- store avatar URLs for profiles and chat messages
- show avatars on the nav bar and in staff chat
- include migrations for new columns
- fix missing staff_chat_messages table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875bc293d30832aa9c55d0ea6664d69