### PR TITLE
Fix dashboard metrics query

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ BEGIN
            AND appointment_date < NOW() + INTERVAL '7 days'),
       (SELECT COUNT(*) FROM product_usage_sessions
          WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
-           AND completed = false),
+           AND is_completed = false),
       (SELECT COUNT(*) FROM products
          WHERE is_active = true
            AND current_stock <= min_threshold),

--- a/migrations/20240915_create_dashboard_metrics_function.sql
+++ b/migrations/20240915_create_dashboard_metrics_function.sql
@@ -15,7 +15,7 @@ BEGIN
   SELECT COUNT(*)
     INTO product_usage_needed
     FROM product_usage_sessions
-    WHERE completed = false;
+    WHERE is_completed = false;
 
   SELECT COUNT(*)
     INTO low_stock

--- a/migrations/20240916_update_dashboard_metrics_for_staff.sql
+++ b/migrations/20240916_update_dashboard_metrics_for_staff.sql
@@ -14,7 +14,7 @@ BEGIN
            AND appointment_date < NOW() + INTERVAL '7 days'),
       (SELECT COUNT(*) FROM product_usage_sessions
          WHERE staff_id = p_staff_id
-           AND completed = false),
+           AND is_completed = false),
       (SELECT COUNT(*) FROM products
          WHERE is_active = true
            AND current_stock <= min_threshold),

--- a/migrations/20240917_allow_null_staff_in_dashboard_metrics.sql
+++ b/migrations/20240917_allow_null_staff_in_dashboard_metrics.sql
@@ -14,7 +14,7 @@ BEGIN
            AND appointment_date < NOW() + INTERVAL '7 days'),
       (SELECT COUNT(*) FROM product_usage_sessions
          WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
-           AND completed = false),
+           AND is_completed = false),
       (SELECT COUNT(*) FROM products
          WHERE is_active = true
            AND current_stock <= min_threshold),


### PR DESCRIPTION
## Summary
- use `is_completed` flag in dashboard metrics SQL
- mention `is_completed` in README example

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876e4aca138832aa1f30d321c21e8e8