### PR TITLE
Handle updatedEvent.currentEntity in webhook router

### DIFF
--- a/api/webhook-router.js
+++ b/api/webhook-router.js
@@ -690,7 +690,11 @@ async function processBookingUpdated(webhookData) {
   try {
     console.log('🔄 Processing booking updated');
     
-    const booking = webhookData.updatedEvent?.entity || webhookData.createdEvent?.entity || webhookData;
+    const booking =
+      webhookData.updatedEvent?.currentEntity ||
+      webhookData.updatedEvent?.entity ||
+      webhookData.createdEvent?.entity ||
+      webhookData;
     
     const updateData = {
       customer_email: booking.contactDetails?.email,

--- a/tests/webhook-router-booking-updated.test.js
+++ b/tests/webhook-router-booking-updated.test.js
@@ -1,0 +1,64 @@
+// tests for api/webhook-router.js booking updated
+const createQuery = (result) => {
+  const promise = Promise.resolve(result);
+  promise.insert = jest.fn(() => promise);
+  promise.update = jest.fn(() => promise);
+  promise.eq = jest.fn(() => promise);
+  promise.select = jest.fn(() => promise);
+  promise.maybeSingle = jest.fn(() => promise);
+  return promise;
+};
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this; }),
+  json: jest.fn(function(){ return this; })
+});
+
+describe('webhook-router booking updated', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.SUPABASE_URL = 'http://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+  });
+
+  test('uses currentEntity when updating booking', async () => {
+    const logsQuery = createQuery({ data: {}, error: null });
+    const bookingQuery = createQuery({ data: { id: '10', wix_booking_id: '10' }, error: null });
+    const from = jest.fn((table) => {
+      if (table === 'webhook_logs') return logsQuery;
+      if (table === 'bookings') return bookingQuery;
+      return createQuery({ data: {}, error: null });
+    });
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+
+    const { default: handler } = await import('../api/webhook-router.js');
+
+    const req = {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: {
+        entityFqdn: 'wix.bookings.v2.booking',
+        slug: 'updated',
+        entityId: '10',
+        updatedEvent: {
+          currentEntity: {
+            id: '10',
+            contactDetails: { email: 'a@b.com', firstName: 'A', lastName: 'B' },
+            paymentStatus: 'PAID',
+            status: 'CONFIRMED'
+          }
+        }
+      }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(from).toHaveBeenCalledWith('bookings');
+    expect(bookingQuery.update).toHaveBeenCalled();
+    expect(bookingQuery.eq).toHaveBeenCalledWith('wix_booking_id', '10');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+});


### PR DESCRIPTION
## Summary
- handle `currentEntity` in `processBookingUpdated`
- test webhook router booking update with currentEntity

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876eee04ea0832a85b830648192e2e3