### PR TITLE
Support payment_status_updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 - `POST /api/order-paid` - Purchase completions
 - `POST /api/invoice-paid` - Invoice payments
 - `POST /api/payment-approved` - Wix Cashier payment events
+- `payment_status_updated` events are handled via `/api/webhook-router`
 
 ### Analytics Webhooks
 - `POST /api/session-ended` - Website visitor sessions

--- a/api/webhook-router.js
+++ b/api/webhook-router.js
@@ -396,6 +396,7 @@ async function processOrderEventJWT(event, eventData = null) {
       eventData ||
       event?.updatedEvent?.currentEntity ||
       event?.createdEvent?.entity ||
+      event?.actionEvent?.body?.order ||
       event;
 
     const orderRecord = {
@@ -412,6 +413,8 @@ async function processOrderEventJWT(event, eventData = null) {
         orderData.total,
       currency: orderData.currency || 'USD',
       payment_status: orderData.paymentStatus || 'NOT_PAID',
+      previous_payment_status:
+        event?.actionEvent?.body?.previousPaymentStatus,
       fulfillment_status: orderData.fulfillmentStatus || orderData.status,
       items: orderData.lineItems || orderData.items,
       billing_info: orderData.billingInfo,

--- a/tests/webhook-router-payment-status-updated.test.js
+++ b/tests/webhook-router-payment-status-updated.test.js
@@ -1,0 +1,67 @@
+const createQuery = (result) => {
+  const promise = Promise.resolve(result);
+  promise.insert = jest.fn(() => promise);
+  promise.update = jest.fn(() => promise);
+  promise.upsert = jest.fn(() => promise);
+  promise.eq = jest.fn(() => promise);
+  promise.select = jest.fn(() => promise);
+  promise.maybeSingle = jest.fn(() => promise);
+  return promise;
+};
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this; }),
+  json: jest.fn(function(){ return this; })
+});
+
+describe('webhook-router payment status updated', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.SUPABASE_URL = 'http://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+  });
+
+  test('upserts order with new and previous payment status', async () => {
+    const logsQuery = createQuery({ data: {}, error: null });
+    const orderQuery = createQuery({ data: [{ id: '1', wix_order_id: 'o1' }], error: null });
+    const from = jest.fn((table) => {
+      if (table === 'webhook_logs') return logsQuery;
+      if (table === 'orders') return orderQuery;
+      return createQuery({ data: {}, error: null });
+    });
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+
+    const { default: handler } = await import('../api/webhook-router.js');
+
+    const req = {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: {
+        entityFqdn: 'wix.ecom.v1.order',
+        slug: 'payment_status_updated',
+        actionEvent: {
+          body: {
+            order: {
+              id: 'o1',
+              number: '100',
+              paymentStatus: 'PAID'
+            },
+            previousPaymentStatus: 'NOT_PAID'
+          }
+        }
+      }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(from).toHaveBeenCalledWith('orders');
+    expect(orderQuery.upsert).toHaveBeenCalled();
+    const upsertData = orderQuery.upsert.mock.calls[0][0];
+    expect(upsertData.payment_status).toBe('PAID');
+    expect(upsertData.previous_payment_status).toBe('NOT_PAID');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+});


### PR DESCRIPTION
## Summary
- handle `payment_status_updated` order webhooks in the router
- store previous payment status on order upserts
- test webhook router logic for payment status updated events
- document how payment status updates are handled

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*


------
https://chatgpt.com/codex/tasks/task_e_6876faa23bf8832a8705e6653f3ac6e0