### PR TITLE
Bypass webhook auth in middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -8,6 +8,12 @@ export async function middleware(req) {
     return NextResponse.next()
   }
 
+  // Bypass authentication for Wix webhook router and log incoming headers
+  if (pathname.startsWith('/api/webhook-router')) {
+    console.log('Bypassing middleware for webhook-router. Headers:', Object.fromEntries(req.headers))
+    return NextResponse.next()
+  }
+
   const authHeader = req.headers.get('authorization')
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return new NextResponse('Unauthorized', { status: 401 })


### PR DESCRIPTION
## Summary
- bypass middleware authentication when the webhook router is hit
- log request headers for easier debugging

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687835f606ec832a8fe3c9921a24b441