### PR TITLE
Fix profile fetch with auth

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { createClient } from '@supabase/supabase-js'
+import { fetchWithAuth } from '../utils/api'
 import styles from './NavBar.module.css'
 
 export default function NavBar() {
@@ -39,8 +40,8 @@ export default function NavBar() {
 
   useEffect(() => {
     if (!user) return
-    fetch('/api/profile')
-      .then(res => res.ok ? res.json() : null)
+    fetchWithAuth('/api/profile')
+      .then(res => (res.ok ? res.json() : null))
       .then(data => setProfile(data?.profile || null))
       .catch(() => {})
   }, [user])

--- a/pages/staff-chat.js
+++ b/pages/staff-chat.js
@@ -29,8 +29,8 @@ export default function StaffChat() {
   useEffect(() => {
     loadBranding()
     fetchMessages()
-    fetch('/api/profile')
-      .then(res => res.ok ? res.json() : null)
+    fetchWithAuth('/api/profile')
+      .then(res => (res.ok ? res.json() : null))
       .then(data => setProfile(data?.profile || null))
       .catch(() => {})
 


### PR DESCRIPTION
## Summary
- send authorization when NavBar and staff chat fetch `/api/profile`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68786e9cb80c832aac648da4f047455b