### PR TITLE
Implement receipt uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 | `staff_chat_messages` | Internal staff chat | Message content and timestamps |
 | `purchase_orders` | Supply ordering | Vendor info, totals, status |
 | `purchase_order_items` | Items on a purchase order | Product ID, quantity, cost |
+| `purchase_receipts` | Uploaded receipts | File URLs linked to purchase orders |
 
 ## 🔗 API Endpoints
 
@@ -71,6 +72,8 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 - `POST /api/purchase-order-items` - Add an item to a purchase order
 - `PUT /api/purchase-order-items` - Update a purchase order item
 - `DELETE /api/purchase-order-items` - Delete a purchase order item
+- `GET /api/get-purchase-receipts/[purchaseOrderId]` - List receipts for a purchase order
+- `POST /api/upload-purchase-receipt` - Upload a receipt image and record it
 
 Example usage:
 
@@ -85,6 +88,11 @@ curl '/api/get-customers?search=jane'
 curl -X POST -H 'Content-Type: application/json' \
   -d '{"vendor_id":"123","order_date":"2024-01-01"}' \
   /api/purchase-orders
+
+# Upload a receipt for a purchase order
+curl -X POST -H 'Authorization: Bearer YOUR_TOKEN' \
+  -F purchase_order_id=123 -F receipt=@path/to/file.jpg \
+  /api/upload-purchase-receipt
 ```
 
 ### Dashboard Metrics
@@ -217,7 +225,7 @@ Copy `.env.example` to `.env.local` and fill in your Supabase credentials:
 - `SUPABASE_STORAGE_BUCKET` (e.g., `salon-images`)
 - `NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET` (same as above for the browser)
 - `SUPABASE_CLIENT_UPLOADS_BUCKET` bucket for before/after service photos
-- `SUPABASE_RECEIPTS_BUCKET` bucket for product usage receipts
+- `SUPABASE_RECEIPTS_BUCKET` bucket for uploaded receipts
 - `WIX_API_TOKEN` Wix API token used for booking operations
 - `WIX_WEBHOOK_SECRET` secret used to verify Wix webhooks
 - `ADMIN_USER_IDS` comma-separated Supabase user IDs allowed to view all staff metrics

--- a/api/get-purchase-receipts/[purchaseOrderId].js
+++ b/api/get-purchase-receipts/[purchaseOrderId].js
@@ -1,0 +1,39 @@
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../../utils/cors'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'GET')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const { purchaseOrderId } = req.query
+    if (!purchaseOrderId) {
+      return res.status(400).json({ error: 'purchaseOrderId is required' })
+    }
+
+    const { data, error } = await supabase
+      .from('purchase_receipts')
+      .select('*')
+      .eq('purchase_order_id', purchaseOrderId)
+      .order('uploaded_at', { ascending: true })
+
+    if (error) throw error
+
+    res.status(200).json({ success: true, receipts: data || [] })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: err.message })
+  }
+}

--- a/api/upload-purchase-receipt.js
+++ b/api/upload-purchase-receipt.js
@@ -1,0 +1,94 @@
+import formidable from 'formidable'
+import fs from 'fs'
+import path from 'path'
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
+import requireAuth from '../utils/requireAuth'
+
+export const config = { api: { bodyParser: false } }
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'POST')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  const user = await requireAuth(req, res)
+  if (!user) return
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const form = formidable({ maxFileSize: 20 * 1024 * 1024, keepExtensions: true })
+  const parseForm = () =>
+    new Promise((resolve, reject) => {
+      form.parse(req, (err, fields, files) => {
+        if (err) return reject(err)
+        resolve({ fields, files })
+      })
+    })
+
+  try {
+    const { fields, files } = await parseForm()
+    const fileField = files.receipt || files.file || files.image
+    if (!fileField) {
+      return res.status(400).json({ error: 'No file uploaded' })
+    }
+    const file = Array.isArray(fileField) ? fileField[0] : fileField
+
+    const purchaseOrderId = Array.isArray(fields.purchase_order_id)
+      ? fields.purchase_order_id[0]
+      : fields.purchase_order_id
+
+    if (!purchaseOrderId) {
+      return res.status(400).json({ error: 'purchase_order_id required' })
+    }
+
+    const bucket = process.env.SUPABASE_RECEIPTS_BUCKET || 'product-usage-images'
+    const ext = path.extname(file.originalFilename || '.jpg').toLowerCase()
+    const filename = `receipt-${purchaseOrderId}-${Date.now()}${ext}`
+    const storagePath = `purchase-receipts/${purchaseOrderId}/${filename}`
+    const buffer = fs.readFileSync(file.filepath)
+    const { error: uploadError } = await supabase.storage
+      .from(bucket)
+      .upload(storagePath, buffer, { contentType: file.mimetype })
+    fs.unlinkSync(file.filepath)
+
+    if (uploadError) {
+      console.error('❌ Upload error:', uploadError)
+      return res.status(500).json({ error: 'Failed to upload receipt' })
+    }
+
+    const { data: publicData } = supabase.storage.from(bucket).getPublicUrl(storagePath)
+    const fileUrl = publicData.publicUrl
+
+    const { data, error } = await supabase
+      .from('purchase_receipts')
+      .insert({
+        purchase_order_id: purchaseOrderId,
+        receipt_url: fileUrl,
+        file_name: filename,
+        uploaded_by: user.id
+      })
+      .select()
+      .single()
+
+    if (error) {
+      console.error('❌ DB insert error:', error)
+      return res.status(500).json({ error: 'Failed to save receipt record' })
+    }
+
+    res.status(200).json({ receipt: data })
+  } catch (err) {
+    console.error('❌ Unexpected error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/migrations/20250102_create_purchase_receipts_table.sql
+++ b/migrations/20250102_create_purchase_receipts_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS purchase_receipts (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  purchase_order_id bigint REFERENCES purchase_orders(id) ON DELETE CASCADE,
+  receipt_url text,
+  file_name text,
+  uploaded_at timestamptz DEFAULT now(),
+  uploaded_by uuid REFERENCES auth.users(id)
+);


### PR DESCRIPTION
## Summary
- add purchase_receipts table migration
- allow staff to upload purchase receipts
- fetch uploaded receipts by purchase order
- document new endpoints and env var
- fix purchase_receipts FK type

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b0bb5ed18832a8c8843422350b499