### PR TITLE
Add staff filter to appointment API

### DIFF
--- a/tests/get-appointments.test.js
+++ b/tests/get-appointments.test.js
@@ -18,6 +18,7 @@ beforeEach(() => {
   jest.resetModules();
   process.env.SUPABASE_URL = 'http://example.supabase.co';
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+  process.env.ADMIN_USER_IDS = 'admin1,admin2';
 });
 
 describe('get-appointments handler', () => {
@@ -25,6 +26,7 @@ describe('get-appointments handler', () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }));
     jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'u1' })));
 
     const { default: handler } = await import('../api/get-appointments.js');
 
@@ -41,6 +43,7 @@ describe('get-appointments handler', () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }));
     jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'u1' })));
 
     const { default: handler } = await import('../api/get-appointments.js');
 
@@ -52,4 +55,38 @@ describe('get-appointments handler', () => {
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({ error: 'Invalid page or limit parameter' });
   });
+
+  test('non-admin cannot override staff_id', async () => {
+    const query = createQuery({ data: [], error: null })
+    const from = jest.fn(() => query)
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' })))
+
+    const { default: handler } = await import('../api/get-appointments.js')
+
+    const req = { method: 'GET', query: { staff_id: 'other' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(query.eq).toHaveBeenCalledWith('staff_id', 'user1')
+  })
+
+  test('admin can request appointments for any staff', async () => {
+    const query = createQuery({ data: [], error: null })
+    const from = jest.fn(() => query)
+    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'admin1' })))
+
+    const { default: handler } = await import('../api/get-appointments.js')
+
+    const req = { method: 'GET', query: { staff_id: 'staff2' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(query.eq).toHaveBeenCalledWith('staff_id', 'staff2')
+  })
 });


### PR DESCRIPTION
## Summary
- enforce authentication and admin checks for `get-appointments`
- allow filtering appointments by staff member
- update tests for the new behaviour

## Testing
- `npm test` *(fails: npm not available)*

------
https://chatgpt.com/codex/tasks/task_e_687b1c66fc44832aad082d4363ff3c08