### PR TITLE
Add Wix analytics metrics query

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ WIX_CLIENT_ID=your-wix-client-id
 WIX_CLIENT_SECRET=your-wix-client-secret
 NEXT_PUBLIC_WIX_CLIENT_ID=your-wix-client-id
 NEXT_PUBLIC_WIX_REDIRECT_URI=http://localhost:3000/api/wix-oauth-callback
+WIX_API_AUTH=Bearer your-wix-server-api-key
 
 # Optional: Email Notifications
 NOTIFICATION_EMAIL=your-email@keepingitcute.com

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 - `DELETE /api/purchase-order-items` - Delete a purchase order item
 - `GET /api/get-purchase-receipts/[purchaseOrderId]` - List receipts for a purchase order
 - `POST /api/upload-purchase-receipt` - Upload a receipt image and record it
+- `GET /api/get-site-analytics` - Query Wix site analytics metrics
 
 Example usage:
 
@@ -228,6 +229,7 @@ Copy `.env.example` to `.env.local` and fill in your Supabase credentials:
 - `SUPABASE_RECEIPTS_BUCKET` bucket for uploaded receipts
 - `WIX_API_TOKEN` Wix API token used for booking operations
 - `WIX_WEBHOOK_SECRET` secret used to verify Wix webhooks
+- `WIX_API_AUTH` Authorization header value for Wix analytics requests
 - `ADMIN_USER_IDS` comma-separated Supabase user IDs allowed to view all staff metrics
 
 Generate these values in the **Wix Developer Center** by creating (or selecting)

--- a/api/get-site-analytics.js
+++ b/api/get-site-analytics.js
@@ -1,0 +1,54 @@
+import { setCorsHeaders } from '../utils/cors'
+import requireAuth from '../utils/requireAuth'
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'GET')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const user = await requireAuth(req, res)
+    if (!user) return
+
+    const { measurement_types = [], 'date_range.start_date': startDate, 'date_range.end_date': endDate, time_zone: timeZone } = req.query
+    if (!measurement_types.length) {
+      return res.status(400).json({ error: 'measurement_types is required' })
+    }
+
+    const params = new URLSearchParams()
+    if (startDate) params.append('date_range.start_date', startDate)
+    if (endDate) params.append('date_range.end_date', endDate)
+    if (timeZone) params.append('time_zone', timeZone)
+    ;(Array.isArray(measurement_types) ? measurement_types : [measurement_types]).forEach((t) => {
+      params.append('measurement_types[]', t)
+    })
+
+    const url = `https://www.wixapis.com/analytics/v2/site-analytics/data?${params.toString()}`
+
+    const apiRes = await fetch(url, {
+      headers: {
+        Authorization: process.env.WIX_API_AUTH || '',
+        'Content-type': 'application/json'
+      }
+    })
+
+    const text = await apiRes.text()
+    if (!apiRes.ok) {
+      console.error('Wix analytics error', text)
+      return res.status(apiRes.status).json({ error: 'Failed to fetch analytics', details: text })
+    }
+
+    const data = JSON.parse(text)
+    res.status(200).json({ success: true, data: data.data || [] })
+  } catch (err) {
+    console.error('Site Analytics Error:', err)
+    res.status(500).json({ error: 'Failed to fetch site analytics', details: err.message })
+  }
+}

--- a/pages/site-analytics.js
+++ b/pages/site-analytics.js
@@ -1,0 +1,102 @@
+import { useState, useEffect } from 'react'
+import Head from 'next/head'
+import { fetchWithAuth } from '../utils/api'
+
+const MEASUREMENTS = [
+  'TOTAL_UNIQUE_VISITORS',
+  'TOTAL_FORMS_SUBMITTED',
+  'TOTAL_SESSIONS',
+  'CLICKS_TO_CONTACT',
+  'TOTAL_ORDERS',
+  'TOTAL_SALES'
+]
+
+export default function SiteAnalytics() {
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [selected, setSelected] = useState(['TOTAL_SESSIONS'])
+  const [data, setData] = useState([])
+  const [error, setError] = useState('')
+
+  const loadData = async () => {
+    try {
+      setError('')
+      const params = new URLSearchParams()
+      if (startDate) params.append('date_range.start_date', startDate)
+      if (endDate) params.append('date_range.end_date', endDate)
+      selected.forEach((m) => params.append('measurement_types', m))
+      const res = await fetchWithAuth(`/api/get-site-analytics?${params.toString()}`)
+      if (!res.ok) {
+        const err = await res.text()
+        throw new Error(err)
+      }
+      const json = await res.json()
+      setData(json.data || [])
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  const toggleMeasurement = (m) => {
+    setSelected((prev) => (prev.includes(m) ? prev.filter((x) => x !== m) : [...prev, m]))
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Site Analytics</title>
+      </Head>
+      <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+        <h1>Site Analytics</h1>
+        <div style={{ marginBottom: '20px' }}>
+          <label style={{ marginRight: '10px' }}>
+            Start Date:
+            <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
+          </label>
+          <label style={{ marginRight: '10px' }}>
+            End Date:
+            <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
+          </label>
+        </div>
+        <div style={{ marginBottom: '20px' }}>
+          {MEASUREMENTS.map((m) => (
+            <label key={m} style={{ marginRight: '15px' }}>
+              <input type="checkbox" checked={selected.includes(m)} onChange={() => toggleMeasurement(m)} />{' '}
+              {m}
+            </label>
+          ))}
+        </div>
+        <button onClick={loadData} style={{ padding: '8px 16px', marginBottom: '20px' }}>
+          Run Query
+        </button>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+        {data.map((item) => (
+          <div key={item.type} style={{ marginBottom: '20px' }}>
+            <h3>{item.type}</h3>
+            <p>Total: {item.total}</p>
+            <table border="1" cellPadding="5" style={{ borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {item.values.map((v) => (
+                  <tr key={v.date}>
+                    <td>{v.date}</td>
+                    <td>{v.value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/api/get-site-analytics` route to fetch Wix analytics
- create `/pages/site-analytics` page to view metrics
- document new API endpoint and auth variable
- note WIX_API_AUTH in env example

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b1f587e50832aaaa7446d01160456