### PR TITLE
Add endpoint to mark bookings as paid

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 - `POST /api/booking-canceled` - Cancellations
 - `POST /api/cancel-booking/[bookingId]` - Cancel a booking via Wix API
 - `POST /api/reschedule-booking/[bookingId]` - Reschedule a booking via Wix API
+- `POST /api/mark-booking-paid/[bookingId]` - Mark a booking and its order as paid
 
 ### Customer Webhooks
 - `POST /api/contact-created` - New customer registrations
@@ -62,6 +63,7 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 - `GET /api/get-customers` - Fetch customer records
 - `POST /api/create-booking` - Create a Wix appointment booking
 - `POST /api/create-checkout` - Generate a Wix checkout session for payments
+- `POST /api/mark-booking-paid/[bookingId]` - Mark a booking and order as paid
 - `GET /api/staff-chat` - Retrieve recent staff chat messages
 - `POST /api/staff-chat` - Post a new staff chat message
 - `GET /api/purchase-orders` - Retrieve purchase orders

--- a/api/mark-booking-paid/[bookingId].js
+++ b/api/mark-booking-paid/[bookingId].js
@@ -1,0 +1,52 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { bookingId } = req.query
+
+  if (!bookingId) {
+    return res.status(400).json({ error: 'bookingId is required' })
+  }
+
+  try {
+    const { data: booking, error } = await supabase
+      .from('bookings')
+      .select('wix_order_id')
+      .eq('id', bookingId)
+      .maybeSingle()
+
+    if (error) {
+      console.error('Fetch booking error:', error)
+      return res.status(500).json({ error: 'Failed to fetch booking', details: error.message })
+    }
+
+    if (!booking) {
+      return res.status(404).json({ error: 'Booking not found' })
+    }
+
+    await supabase
+      .from('bookings')
+      .update({ payment_status: 'paid', updated_at: new Date().toISOString() })
+      .eq('id', bookingId)
+
+    if (booking.wix_order_id) {
+      await supabase
+        .from('orders')
+        .update({ payment_status: 'paid', updated_at: new Date().toISOString() })
+        .eq('wix_order_id', booking.wix_order_id)
+    }
+
+    res.status(200).json({ success: true })
+  } catch (err) {
+    console.error('Mark paid error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -293,6 +293,37 @@ export default function StaffPortal() {
     }
   }
 
+  const markAppointmentPaid = async (appointment) => {
+    if (!appointment) return
+    if (!confirm('Mark this appointment as paid?')) return
+
+    try {
+      const response = await fetchWithAuth(`/api/mark-booking-paid/${appointment.id}`, {
+        method: 'POST'
+      })
+
+      if (!response.ok) throw new Error('Mark paid failed')
+
+      setAppointments(
+        appointments.map((a) =>
+          a.id === appointment.id ? { ...a, payment_status: 'paid' } : a
+        )
+      )
+
+      if (selectedAppointment?.id === appointment.id) {
+        setSelectedAppointment({
+          ...selectedAppointment,
+          payment_status: 'paid'
+        })
+      }
+
+      alert('Appointment marked as paid')
+    } catch (error) {
+      console.error('Error marking appointment paid:', error)
+      alert('Failed to mark appointment as paid')
+    }
+  }
+
   const navigateToAudit = () => {
     router.push('/inventory-audit')
   }
@@ -1645,6 +1676,22 @@ export default function StaffPortal() {
                         }}
                       >
                         Collect Payment
+                      </button>
+                    )}
+                    {selectedAppointment.payment_status !== 'paid' && (
+                      <button
+                        onClick={() => markAppointmentPaid(selectedAppointment)}
+                        style={{
+                          background: '#2e7d32',
+                          color: 'white',
+                          border: 'none',
+                          padding: '12px 20px',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                          fontSize: '14px'
+                        }}
+                      >
+                        Mark Paid
                       </button>
                     )}
                   </>


### PR DESCRIPTION
## Summary
- allow staff to mark bookings paid and update the related order
- expose new API endpoint in README
- add manual payment button on the staff page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c488ede1c832a816f4d2b463a364a