### PR TITLE
Add site analytics link

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -113,6 +113,7 @@ export default function Dashboard() {
           <Link href="/product-usage-dashboard" style={{ padding: '10px 15px', background: '#e0cdbb', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>Log Product Usage</Link>
           <Link href="/staff?tab=appointments" style={{ padding: '10px 15px', background: '#667eea', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>View All Appointments</Link>
           <Link href="/alerts" style={{ padding: '10px 15px', background: '#d32f2f', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>Restock Inventory</Link>
+          <Link href="/site-analytics" style={{ padding: '10px 15px', background: '#1976d2', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>Site Analytics</Link>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- extend Quick Links on the dashboard with a Site Analytics link

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c518656fc832aac530f5b80b3d6c1