### PR TITLE
Add webhook logging

### DIFF
--- a/api/webhook.js
+++ b/api/webhook.js
@@ -1,14 +1,35 @@
 
+import { createClient } from '@supabase/supabase-js'
+import { setCorsHeaders } from '../utils/cors'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
 export default async function handler(req, res) {
-  if (req.method === 'POST') {
-    const payload = req.body;
+  setCorsHeaders(res, ['POST', 'OPTIONS'])
 
-    console.log("✅ Webhook received:", payload);
-
-    // Forward logic or storage here
-
-    res.status(200).json({ status: 'Webhook received', data: payload });
-  } else {
-    res.status(405).json({ error: 'Method not allowed' });
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
   }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const payload = req.body
+
+  try {
+    await supabase.from('webhook_logs').insert({
+      event_type: req.headers['x-wix-event'] || 'unknown',
+      payload,
+      logged_at: new Date().toISOString()
+    })
+  } catch (err) {
+    console.error('Webhook log insert error:', err)
+  }
+
+  console.log('✅ Webhook received')
+  res.status(200).json({ status: 'Webhook received' })
 }

--- a/migrations/20250103_create_webhook_logs_table.sql
+++ b/migrations/20250103_create_webhook_logs_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS webhook_logs (
+  id serial PRIMARY KEY,
+  event_type text,
+  payload jsonb,
+  logged_at timestamptz DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- log webhook payloads to `webhook_logs` table
- create migration for `webhook_logs`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d1e1f6e50832aaafcbd3799149c01