### PR TITLE
Add appointment pagination

### DIFF
--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -28,11 +28,14 @@ export default async function handler(req, res) {
       return res.status(400).json({ error: 'Invalid page or limit parameter' });
     }
     
+    const from = (pageNum - 1) * limitNum;
+    const to = from + limitNum - 1;
+
     let query = supabase
       .from('bookings')
       .select('*, salon_services(*)')
       .order('appointment_date', { ascending: false })
-      .limit(limitNum);
+      .range(from, to);
     
     if (status) {
       query = query.eq('status', status);


### PR DESCRIPTION
## Summary
- support paginated fetches in `api/get-appointments`
- allow loading additional appointments from staff portal and appointments page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687da7e4b1d8832a81c0b264d4c63de8