### PR TITLE
Fix staff notes display

### DIFF
--- a/pages/staff.js
+++ b/pages/staff.js
@@ -935,7 +935,8 @@ export default function StaffPortal() {
                           color: '#666',
                           fontStyle: 'italic'
                         }}>
-                          💬 "{appointment.notes.substring(0, 50)}{appointment.notes.length > 50 ? '...' : ''}"
+                          💬 {appointment.notes.substring(0, 50)}
+                          {appointment.notes.length > 50 ? '...' : ''}
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
## Summary
- fix `notes` JSX in staff page to remove unnecessary quotes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687daf3a53f0832abc56ce01e3a414c3