### PR TITLE
Replace limit mock with range

### DIFF
--- a/tests/get-appointments.test.js
+++ b/tests/get-appointments.test.js
@@ -3,7 +3,7 @@ const createQuery = (result) => {
   const promise = Promise.resolve(result);
   promise.select = jest.fn(() => promise);
   promise.order = jest.fn(() => promise);
-  promise.limit = jest.fn(() => promise);
+  promise.range = jest.fn(() => promise);
   promise.eq = jest.fn(() => promise);
   return promise;
 };


### PR DESCRIPTION
## Summary
- update get-appointments test to mock `.range`

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687db134891c832ab13022739b565556