### PR TITLE
Increase appointment fetch limit

### DIFF
--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -20,7 +20,7 @@ export default async function handler(req, res) {
   }
   
   try {
-    const { page = '1', limit = '50', status, payment_status } = req.query
+    const { page = '1', limit = '1000', status, payment_status } = req.query
 
     const pageNum = parseInt(page, 10);
     const limitNum = parseInt(limit, 10);

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -88,7 +88,7 @@ export default function StaffPortal() {
       console.log('Services loaded:', servicesData.stats?.total_services)
 
       // Load appointments
-      const appointmentsResponse = await fetchWithAuth('/api/get-appointments')
+      const appointmentsResponse = await fetchWithAuth('/api/get-appointments?limit=1000')
       if (!appointmentsResponse.ok) {
         throw new Error(`Appointments API Error: ${appointmentsResponse.status}`)
       }


### PR DESCRIPTION
## Summary
- allow up to 1000 appointments by default in the API
- request up to 1000 records in the staff portal

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802f51accc832a87b5c343e5a03ba3