### PR TITLE
Add Wix OAuth callback page and token exchange route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ WIX_API_TOKEN=your-wix-api-token
 WIX_CLIENT_ID=your-wix-client-id
 WIX_CLIENT_SECRET=your-wix-client-secret
 NEXT_PUBLIC_WIX_CLIENT_ID=your-wix-client-id
-NEXT_PUBLIC_WIX_REDIRECT_URI=http://localhost:3000/api/wix-oauth-callback
+NEXT_PUBLIC_WIX_REDIRECT_URI=https://wix-keeping-it-cute-app.vercel.app/oauth/callback
 WIX_API_AUTH=Bearer your-wix-server-api-key
 
 # Optional: Email Notifications

--- a/pages/api/exchange-code.js
+++ b/pages/api/exchange-code.js
@@ -1,0 +1,25 @@
+export default async function handler(req, res) {
+  const { code } = req.body
+
+  const response = await fetch('https://www.wixapis.com/oauth/access', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      client_id: process.env.WIX_CLIENT_ID,
+      client_secret: process.env.WIX_CLIENT_SECRET,
+      code,
+      redirect_uri: process.env.NEXT_PUBLIC_WIX_REDIRECT_URI,
+    }),
+  })
+
+  const data = await response.json()
+
+  if (data.access_token) {
+    res.status(200).json({ success: true, token: data })
+  } else {
+    res.status(400).json({ success: false, error: data })
+  }
+}

--- a/pages/oauth/callback.js
+++ b/pages/oauth/callback.js
@@ -1,0 +1,33 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function OAuthCallback() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const handleOAuth = async () => {
+      if (!router.isReady) return
+      const { code } = router.query
+      if (code) {
+        try {
+          const response = await fetch('/api/exchange-code', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ code }),
+          })
+          const result = await response.json()
+          if (result.success) {
+            router.push('/dashboard')
+          } else {
+            console.error('OAuth error:', result.error)
+          }
+        } catch (err) {
+          console.error('OAuth exchange failed', err)
+        }
+      }
+    }
+    handleOAuth()
+  }, [router])
+
+  return <p>Authenticating…</p>
+}


### PR DESCRIPTION
## Summary
- add `/oauth/callback` page that exchanges the Wix OAuth code
- add API route `/api/exchange-code` used by the callback page
- update example env to use the new redirect URL

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688648735028832aa01bdec646e2d5fd