### PR TITLE
Add Wix webhook verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,10 @@ Copy `.env.example` to `.env.local` and fill in your Supabase credentials:
 
 Generate these values in the **Wix Developer Center** by creating (or selecting)
 an app and navigating to **API Keys**. Create a new API key for server-to-server
-calls and copy it into `WIX_API_TOKEN`. Add a webhook secret and place its value
-in `WIX_WEBHOOK_SECRET`. Put both variables in `.env.local` during development or
-set them as environment variables in your deployment platform. The webhook
-secret is currently unused unless you implement request verification.
+calls and copy it into `WIX_API_TOKEN`. Under **Webhooks**, generate a secret and
+place its value in `WIX_WEBHOOK_SECRET`. Put both variables in `.env.local` during
+development or set them as environment variables in your deployment platform.
+The secret is used to validate the `x-wix-webhook-signature` header.
 
 These values are required to build and run the API routes. Variables prefixed
 with `NEXT_PUBLIC_` are exposed to the browser, while server-side handlers rely


### PR DESCRIPTION
## Summary
- verify incoming webhook signature in `webhook-router.js`
- explain in README how to obtain and use the webhook secret

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_688658d13360832ab74812786dc79a35