### PR TITLE
Refactor API to use shared Supabase client

### DIFF
--- a/api/appointments.js
+++ b/api/appointments.js
@@ -1,10 +1,7 @@
 // api/appointments.js - Get appointments with filtering
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {

--- a/api/booking-canceled.js
+++ b/api/booking-canceled.js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { addNotification } from '../utils/notifications'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/booking-created-enhanced.js
+++ b/api/booking-created-enhanced.js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   // Add comprehensive logging
@@ -28,8 +25,6 @@ export default async function handler(req, res) {
   try {
     // Log environment variables (without exposing secrets)
     console.log('🔍 Environment Check:')
-    console.log('SUPABASE_URL:', process.env.SUPABASE_URL ? '✅ Set' : '❌ Missing')
-    console.log('SUPABASE_SERVICE_ROLE_KEY:', process.env.SUPABASE_SERVICE_ROLE_KEY ? '✅ Set' : '❌ Missing')
     
     const bookingData = req.body
     console.log('📅 Processing booking data:', bookingData)

--- a/api/booking-created.js
+++ b/api/booking-created.js
@@ -1,12 +1,9 @@
 // api/booking-created.js - COMPLETE CORRECTED VERSION
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 import { addNotification } from '../utils/notifications'
 
-const supabase = createClient(
- process.env.SUPABASE_URL,
- process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'POST');

--- a/api/booking-updated.js
+++ b/api/booking-updated.js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { addNotification } from '../utils/notifications'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/cancel-booking/[bookingId].js
+++ b/api/cancel-booking/[bookingId].js
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/complete-booking/[bookingId].js
+++ b/api/complete-booking/[bookingId].js
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/complete-usage-session.js
+++ b/api/complete-usage-session.js
@@ -1,12 +1,9 @@
 // api/complete-usage-session.js
 // Mark a product usage session as completed or create it if it doesn't exist
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'POST');

--- a/api/contact-created.js
+++ b/api/contact-created.js
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/contact-updated.js
+++ b/api/contact-updated.js
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/create-booking.js
+++ b/api/create-booking.js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'POST')

--- a/api/create-product.js
+++ b/api/create-product.js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'POST')

--- a/api/dashboard-stats.js
+++ b/api/dashboard-stats.js
@@ -1,10 +1,7 @@
 // api/dashboard-stats.js - Business dashboard statistics
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {

--- a/api/fix-logo-setup.js
+++ b/api/fix-logo-setup.js
@@ -1,12 +1,9 @@
 // api/fix-logo-setup.js - Run this ONCE to fix your logo setup
 import fs from 'fs'
 import path from 'path'
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   try {

--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -1,11 +1,8 @@
 // api/get-appointments.js
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET');

--- a/api/get-booking-images/[bookingId].js
+++ b/api/get-booking-images/[bookingId].js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../../utils/supabaseClient'
 import { setCorsHeaders } from '../../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET')

--- a/api/get-booking/[bookingId].js
+++ b/api/get-booking/[bookingId].js
@@ -1,11 +1,8 @@
 // api/get-booking/[bookingId].js
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../../utils/supabaseClient'
 import { setCorsHeaders } from '../../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET');

--- a/api/get-branding.js
+++ b/api/get-branding.js
@@ -1,11 +1,8 @@
 // api/get-branding.js - UPDATED VERSION (replace your existing file)
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 const BUCKET = process.env.SUPABASE_STORAGE_BUCKET || 'salon-images'
 
 export default async function handler(req, res) {

--- a/api/get-customers.js
+++ b/api/get-customers.js
@@ -1,11 +1,8 @@
 // api/get-customers.js
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET')

--- a/api/get-dashboard-metrics.js
+++ b/api/get-dashboard-metrics.js
@@ -1,5 +1,5 @@
 // api/get-dashboard-metrics.js
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 import requireAuth from '../utils/requireAuth'
 
@@ -8,10 +8,7 @@ const ADMIN_IDS = (process.env.ADMIN_USER_IDS || '')
   .map((id) => id.trim())
   .filter(Boolean)
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET')

--- a/api/get-inventory-alerts.js
+++ b/api/get-inventory-alerts.js
@@ -1,12 +1,9 @@
 // api/get-inventory-alerts.js - Simplified for your current schema
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 import { addNotification, loadNotifications } from '../utils/notifications'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET');

--- a/api/get-loyalty.js
+++ b/api/get-loyalty.js
@@ -1,11 +1,8 @@
 // api/get-loyalty.js
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET')

--- a/api/get-order-bookings.js
+++ b/api/get-order-bookings.js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET')

--- a/api/get-orders.js
+++ b/api/get-orders.js
@@ -1,11 +1,8 @@
 // api/get-orders.js
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET');

--- a/api/get-products.js
+++ b/api/get-products.js
@@ -1,11 +1,8 @@
 // api/get-products.js - Corrected for your schema
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET')

--- a/api/get-purchase-receipts/[purchaseOrderId].js
+++ b/api/get-purchase-receipts/[purchaseOrderId].js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../../utils/supabaseClient'
 import { setCorsHeaders } from '../../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET')

--- a/api/get-service/[serviceId].js
+++ b/api/get-service/[serviceId].js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../../utils/supabaseClient'
 import { setCorsHeaders } from '../../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET')

--- a/api/invoice-paid.js
+++ b/api/invoice-paid.js
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/log-product-usage.js
+++ b/api/log-product-usage.js
@@ -1,12 +1,9 @@
 // api/log-product-usage.js
 // Log individual product usage during a session
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { addNotification } from '../utils/notifications'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/mark-booking-paid/[bookingId].js
+++ b/api/mark-booking-paid/[bookingId].js
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/order-paid.js
+++ b/api/order-paid.js
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/order-updated.js
+++ b/api/order-updated.js
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/payment-approved.js
+++ b/api/payment-approved.js
@@ -1,11 +1,8 @@
 // api/payment-approved.js - New webhook for Wix payment processing
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'POST');

--- a/api/product-usage-stats.js
+++ b/api/product-usage-stats.js
@@ -1,11 +1,8 @@
 // api/product-usage-stats.js
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET');

--- a/api/products/[id].js
+++ b/api/products/[id].js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../../utils/supabaseClient'
 import { setCorsHeaders } from '../../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET')

--- a/api/profile.js
+++ b/api/profile.js
@@ -1,11 +1,8 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 import requireAuth from '../utils/requireAuth'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, ['GET', 'POST'])

--- a/api/purchase-order-items.js
+++ b/api/purchase-order-items.js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, ['GET', 'POST', 'PUT', 'DELETE'])

--- a/api/purchase-orders.js
+++ b/api/purchase-orders.js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, ['GET', 'POST', 'PUT', 'DELETE'])

--- a/api/record-stock-adjustment.js
+++ b/api/record-stock-adjustment.js
@@ -1,10 +1,7 @@
 // api/record-stock-adjustment.js - Log manual stock corrections
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/reschedule-booking/[bookingId].js
+++ b/api/reschedule-booking/[bookingId].js
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/services.js
+++ b/api/services.js
@@ -1,11 +1,8 @@
 // api/services.js - Get salon services
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET');

--- a/api/services/[id].js
+++ b/api/services/[id].js
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../../utils/supabaseClient'
 import { setCorsHeaders } from '../../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'GET')

--- a/api/session-ended.js
+++ b/api/session-ended.js
@@ -1,9 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/staff-chat.js
+++ b/api/staff-chat.js
@@ -1,12 +1,9 @@
 // api/staff-chat.js - Staff chat messages API
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 import requireAuth from '../utils/requireAuth'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, ['GET', 'POST'])

--- a/api/start-usage-session.js
+++ b/api/start-usage-session.js
@@ -1,11 +1,8 @@
 // api/start-usage-session.js
 // Start a new product usage session (when service begins)
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/submit-inventory-audit.js
+++ b/api/submit-inventory-audit.js
@@ -1,10 +1,7 @@
 // api/submit-inventory-audit.js - Simplified without email
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {

--- a/api/test-db.js
+++ b/api/test-db.js
@@ -1,15 +1,10 @@
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   try {
     console.log('🔍 Testing Supabase connection...')
-    console.log('URL:', process.env.SUPABASE_URL ? '✅ Set' : '❌ Missing')
-    console.log('Key:', process.env.SUPABASE_SERVICE_ROLE_KEY ? '✅ Set' : '❌ Missing')
     
     // Test simple query
     const { data, error } = await supabase

--- a/api/update-appointment-notes.js
+++ b/api/update-appointment-notes.js
@@ -1,11 +1,8 @@
 // api/update-appointment-notes.js - Save appointment notes
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'POST');

--- a/api/update-loyalty-points.js
+++ b/api/update-loyalty-points.js
@@ -1,11 +1,8 @@
 // api/update-loyalty-points.js - add or redeem loyalty points
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'POST')

--- a/api/update-product-image.js
+++ b/api/update-product-image.js
@@ -1,11 +1,8 @@
 // api/update-product-image.js - Update product images
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'POST, PUT');

--- a/api/upload-booking-file.js
+++ b/api/upload-booking-file.js
@@ -1,13 +1,10 @@
 import formidable from 'formidable'
 import fs from 'fs'
 import path from 'path'
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export const config = {
   api: { bodyParser: false }

--- a/api/upload-favicon.js
+++ b/api/upload-favicon.js
@@ -1,13 +1,10 @@
 import formidable from 'formidable'
 import fs from 'fs'
 import path from 'path'
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export const config = {
   api: {

--- a/api/upload-image.js
+++ b/api/upload-image.js
@@ -1,13 +1,10 @@
 // api/upload-image.js - Simple image upload handler
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import formidable from 'formidable'
 import fs from 'fs'
 import path from 'path'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export const config = {
   api: {

--- a/api/upload-product-image.js
+++ b/api/upload-product-image.js
@@ -2,14 +2,11 @@
 import formidable from 'formidable'
 import fs from 'fs'
 import path from 'path'
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 import logger from '../utils/logger'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 // CRITICAL: Disable Next.js body parser for file uploads
 export const config = {

--- a/api/upload-purchase-receipt.js
+++ b/api/upload-purchase-receipt.js
@@ -1,16 +1,13 @@
 import formidable from 'formidable'
 import fs from 'fs'
 import path from 'path'
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 import requireAuth from '../utils/requireAuth'
 
 export const config = { api: { bodyParser: false } }
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'POST')

--- a/api/upload-salon-logo.js
+++ b/api/upload-salon-logo.js
@@ -2,13 +2,10 @@
 import formidable from 'formidable'
 import fs from 'fs'
 import path from 'path'
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export const config = {
   api: {

--- a/api/upload-staff-avatar.js
+++ b/api/upload-staff-avatar.js
@@ -1,7 +1,7 @@
 import formidable from 'formidable'
 import fs from 'fs'
 import path from 'path'
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 import requireAuth from '../utils/requireAuth'
 
@@ -9,10 +9,7 @@ export const config = {
   api: { bodyParser: false }
 }
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, 'POST')

--- a/api/webhook-router.js
+++ b/api/webhook-router.js
@@ -1,12 +1,9 @@
 // api/webhook-router.js - FINAL VERSION with fixed labels and upserts
 import jwt from 'jsonwebtoken';
-import { createClient } from '@supabase/supabase-js';
+import { createSupabaseClient } from '../utils/supabaseClient';
 import { setCorsHeaders } from '../utils/cors';
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-);
+const supabase = createSupabaseClient()
 
 // Wix public key used to verify signed webhook payloads.
 const { WIX_PUBLIC_KEY } = process.env;

--- a/api/webhook.js
+++ b/api/webhook.js
@@ -1,11 +1,8 @@
 
-import { createClient } from '@supabase/supabase-js'
+import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
+const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
   setCorsHeaders(res, ['POST', 'OPTIONS'])

--- a/tests/booking-updated.test.js
+++ b/tests/booking-updated.test.js
@@ -28,7 +28,7 @@ describe('booking-updated handler', () => {
       if (table === 'product_usage_sessions') return usageQuery;
       return createUpdateQuery({});
     });
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
 
     const { default: handler } = await import('../api/booking-updated.js');
 

--- a/tests/create-booking.test.js
+++ b/tests/create-booking.test.js
@@ -26,7 +26,7 @@ afterEach(() => {
 describe('create-booking handler', () => {
   test('returns 405 on non-POST requests', async () => {
     const from = jest.fn(() => createInsert({ data: {}, error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/create-booking.js')
@@ -42,7 +42,7 @@ describe('create-booking handler', () => {
 
   test('validates required fields', async () => {
     const from = jest.fn(() => createInsert({ data: {}, error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/create-booking.js')
@@ -66,7 +66,7 @@ describe('create-booking handler', () => {
 
     const insertQuery = createInsert({ data: { id: '1' }, error: null })
     const from = jest.fn(() => insertQuery)
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/create-booking.js')

--- a/tests/get-appointments.test.js
+++ b/tests/get-appointments.test.js
@@ -23,7 +23,7 @@ beforeEach(() => {
 describe('get-appointments handler', () => {
   test('rejects non-positive page or limit', async () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }));
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
 
     const { default: handler } = await import('../api/get-appointments.js');
@@ -39,7 +39,7 @@ describe('get-appointments handler', () => {
 
   test('rejects non-numeric page or limit', async () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }));
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
 
     const { default: handler } = await import('../api/get-appointments.js');

--- a/tests/get-customers.test.js
+++ b/tests/get-customers.test.js
@@ -23,7 +23,7 @@ beforeEach(() => {
 describe('get-customers handler', () => {
   test('returns 405 on non-GET requests', async () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }));
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
 
     const { default: handler } = await import('../api/get-customers.js');
@@ -41,7 +41,7 @@ describe('get-customers handler', () => {
     const customersData = [{ id: 1 }];
     const query = createQuery({ data: customersData, error: null });
     const from = jest.fn(() => query);
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
 
     const { default: handler } = await import('../api/get-customers.js');

--- a/tests/get-dashboard-metrics.test.js
+++ b/tests/get-dashboard-metrics.test.js
@@ -13,7 +13,7 @@ describe('get-dashboard-metrics handler', () => {
 
   test('returns 405 on non-GET requests', async () => {
     const rpc = jest.fn(() => Promise.resolve({ data: [], error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ rpc }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ rpc }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
     jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'u1' })))
 
@@ -29,7 +29,7 @@ describe('get-dashboard-metrics handler', () => {
 
   test('non-admin cannot override staff_id', async () => {
     const rpc = jest.fn(() => Promise.resolve({ data: [], error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ rpc }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ rpc }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
     jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' })))
 
@@ -45,7 +45,7 @@ describe('get-dashboard-metrics handler', () => {
 
   test('admin can request metrics for all staff', async () => {
     const rpc = jest.fn(() => Promise.resolve({ data: [], error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ rpc }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ rpc }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
     jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'admin1' })))
 

--- a/tests/get-inventory-alerts.test.js
+++ b/tests/get-inventory-alerts.test.js
@@ -12,7 +12,7 @@ describe('get-inventory-alerts handler', () => {
 
   test('returns 405 on non-GET requests', async () => {
     const rpc = jest.fn(() => Promise.resolve({ data: [], error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ rpc }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ rpc }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/get-inventory-alerts.js')
@@ -34,7 +34,7 @@ describe('get-inventory-alerts handler', () => {
     const rpc = jest.fn(() => Promise.resolve({ data: lowStock, error: null }))
     const addNotification = jest.fn(() => Promise.resolve())
     const loadNotifications = jest.fn(() => Promise.resolve([]))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ rpc }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ rpc }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
     jest.doMock('../utils/notifications', () => ({ addNotification, loadNotifications }))
 

--- a/tests/get-loyalty.test.js
+++ b/tests/get-loyalty.test.js
@@ -23,7 +23,7 @@ beforeEach(() => {
 describe('get-loyalty handler', () => {
   test('returns 405 on non-GET requests', async () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/get-loyalty.js')
@@ -41,7 +41,7 @@ describe('get-loyalty handler', () => {
     const loyaltyData = [{ id: 1 }]
     const query = createQuery({ data: loyaltyData, error: null })
     const from = jest.fn(() => query)
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/get-loyalty.js')
@@ -69,7 +69,7 @@ describe('get-loyalty handler', () => {
     const loyaltyData = [{ id: 1 }]
     const query = createQuery({ data: loyaltyData, error: null })
     const from = jest.fn(() => query)
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/get-loyalty.js')

--- a/tests/get-orders.test.js
+++ b/tests/get-orders.test.js
@@ -23,7 +23,7 @@ beforeEach(() => {
 describe('get-orders handler', () => {
   test('returns 405 on non-GET requests', async () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }));
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
 
     const { default: handler } = await import('../api/get-orders.js');
@@ -39,7 +39,7 @@ describe('get-orders handler', () => {
 
   test('rejects non-numeric or non-positive page/limit', async () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }));
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
 
     const { default: handler } = await import('../api/get-orders.js');
@@ -57,7 +57,7 @@ describe('get-orders handler', () => {
     const ordersData = [{ id: 1 }];
     const query = createQuery({ data: ordersData, error: null });
     const from = jest.fn(() => query);
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
 
     const { default: handler } = await import('../api/get-orders.js');

--- a/tests/log-product-usage.test.js
+++ b/tests/log-product-usage.test.js
@@ -20,7 +20,7 @@ describe('log-product-usage handler', () => {
 
   test('returns 405 on non-POST requests', async () => {
     const from = jest.fn(() => createInsertQuery({ data: [], error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
 
     const { default: handler } = await import('../api/log-product-usage.js')
 
@@ -40,7 +40,7 @@ describe('log-product-usage handler', () => {
     })
     const from = jest.fn(() => insertQuery)
     const addNotification = jest.fn(() => Promise.resolve())
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/notifications', () => ({ addNotification }))
 
     const { default: handler } = await import('../api/log-product-usage.js')

--- a/tests/record-stock-adjustment.test.js
+++ b/tests/record-stock-adjustment.test.js
@@ -23,7 +23,7 @@ describe('record-stock-adjustment handler', () => {
 
   test('returns 405 on non-POST requests', async () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
 
     const { default: handler } = await import('../api/record-stock-adjustment.js')
 
@@ -45,7 +45,7 @@ describe('record-stock-adjustment handler', () => {
       if (table === 'products') return selectQuery
     })
 
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
 
     const { default: handler } = await import('../api/record-stock-adjustment.js')
 

--- a/tests/staff-chat.test.js
+++ b/tests/staff-chat.test.js
@@ -23,7 +23,7 @@ beforeEach(() => {
 describe('staff-chat handler', () => {
   test('returns 405 on unsupported method', async () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/staff-chat.js')
@@ -40,7 +40,7 @@ describe('staff-chat handler', () => {
   test('fetches messages on GET', async () => {
     const query = createQuery({ data: [{ id: '1', content: 'hi' }], error: null })
     const from = jest.fn(() => query)
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/staff-chat.js')
@@ -62,7 +62,7 @@ describe('staff-chat handler', () => {
   test('inserts message on POST', async () => {
     const query = createQuery({ data: { id: '1', content: 'hi' }, error: null })
     const from = jest.fn(() => query)
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
     jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'u1' })))
 

--- a/tests/update-loyalty-points.test.js
+++ b/tests/update-loyalty-points.test.js
@@ -23,7 +23,7 @@ beforeEach(() => {
 describe('update-loyalty-points handler', () => {
   test('returns 405 on non-POST requests', async () => {
     const from = jest.fn(() => createQuery({ data: {}, error: null }))
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/update-loyalty-points.js')
@@ -44,7 +44,7 @@ describe('update-loyalty-points handler', () => {
       .mockReturnValueOnce(selectQuery)
       .mockReturnValueOnce(updateQuery)
 
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/update-loyalty-points.js')

--- a/tests/webhook-router-booking-updated.test.js
+++ b/tests/webhook-router-booking-updated.test.js
@@ -29,7 +29,7 @@ describe('webhook-router booking updated', () => {
       if (table === 'bookings') return bookingQuery;
       return createQuery({ data: {}, error: null });
     });
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
 
     const { default: handler } = await import('../api/webhook-router.js');

--- a/tests/webhook-router-loyalty-updated.test.js
+++ b/tests/webhook-router-loyalty-updated.test.js
@@ -30,7 +30,7 @@ describe('webhook-router loyalty account updated', () => {
       if (table === 'loyalty') return loyaltyQuery
       return createQuery({ data: {}, error: null })
     })
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
 
     const { default: handler } = await import('../api/webhook-router.js')

--- a/tests/webhook-router-payment-status-updated.test.js
+++ b/tests/webhook-router-payment-status-updated.test.js
@@ -29,7 +29,7 @@ describe('webhook-router payment status updated', () => {
       if (table === 'orders') return orderQuery;
       return createQuery({ data: {}, error: null });
     });
-    jest.doMock('@supabase/supabase-js', () => ({ createClient: () => ({ from }) }));
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
 
     const { default: handler } = await import('../api/webhook-router.js');


### PR DESCRIPTION
## Summary
- import `createSupabaseClient` helper across API routes
- replace inline `createClient` usage
- update tests to mock the helper instead of `@supabase/supabase-js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68865e95ed14832aa7e45aba5df9f21d