### PR TITLE
Add tests for service endpoints

### DIFF
--- a/tests/service-details.test.js
+++ b/tests/service-details.test.js
@@ -1,0 +1,140 @@
+const createQuery = (result) => {
+  const promise = Promise.resolve(result)
+  promise.select = jest.fn(() => promise)
+  promise.eq = jest.fn(() => promise)
+  promise.single = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this }),
+  json: jest.fn(function(){ return this }),
+  end: jest.fn(function(){ return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  process.env.SUPABASE_URL = 'http://example.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+})
+
+describe('service detail handler', () => {
+  test('returns 405 on non-GET requests', async () => {
+    const from = jest.fn(() => createQuery({ data: null, error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/services/[id].js')
+
+    const req = { method: 'POST', query: { id: '1' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('returns 400 when id missing', async () => {
+    const from = jest.fn(() => createQuery({ data: null, error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/services/[id].js')
+
+    const req = { method: 'GET', query: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Service ID is required' })
+  })
+
+  test('handles supabase errors', async () => {
+    const from = jest.fn((table) => {
+      if (table === 'salon_services') {
+        return createQuery({ data: null, error: new Error('fail') })
+      }
+      return createQuery({ data: [], error: null })
+    })
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/services/[id].js')
+
+    const req = { method: 'GET', query: { id: '1' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('salon_services')
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Failed to fetch service' }))
+  })
+
+  test('returns 404 when service missing', async () => {
+    const from = jest.fn((table) => createQuery({ data: null, error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/services/[id].js')
+
+    const req = { method: 'GET', query: { id: '1' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(404)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Service not found' })
+  })
+
+  test('fetches service details', async () => {
+    const serviceData = { id: '1', name: 'Cut' }
+    const staffLinks = [{ staff: { id: 's1' } }]
+    const resourceRows = [{ resource_name: 'chair' }]
+    const productLinks = [{ product: { id: 'p1' } }]
+
+    const from = jest.fn((table) => {
+      switch (table) {
+        case 'salon_services':
+          return createQuery({ data: serviceData, error: null })
+        case 'service_staff':
+          return createQuery({ data: staffLinks, error: null })
+        case 'service_resources':
+          return createQuery({ data: resourceRows, error: null })
+        case 'service_products':
+          return createQuery({ data: productLinks, error: null })
+        default:
+          return createQuery({ data: [], error: null })
+      }
+    })
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/services/[id].js')
+
+    const req = { method: 'GET', query: { id: '1' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('salon_services')
+    expect(from).toHaveBeenCalledWith('service_staff')
+    expect(from).toHaveBeenCalledWith('service_resources')
+    expect(from).toHaveBeenCalledWith('service_products')
+
+    const response = res.json.mock.calls[0][0]
+    expect(response).toMatchObject({
+      success: true,
+      service: {
+        id: '1',
+        name: 'Cut',
+        staff: [{ id: 's1' }],
+        resources: ['chair'],
+        products: [{ id: 'p1' }]
+      }
+    })
+    expect(typeof response.timestamp).toBe('string')
+  })
+})

--- a/tests/services.test.js
+++ b/tests/services.test.js
@@ -1,0 +1,83 @@
+const createQuery = (result) => {
+  const promise = Promise.resolve(result)
+  promise.select = jest.fn(() => promise)
+  promise.order = jest.fn(() => promise)
+  promise.eq = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this }),
+  json: jest.fn(function(){ return this }),
+  end: jest.fn(function(){ return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  process.env.SUPABASE_URL = 'http://example.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+})
+
+describe('services handler', () => {
+  test('returns 405 on non-GET requests', async () => {
+    const from = jest.fn(() => createQuery({ data: [], error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/services.js')
+
+    const req = { method: 'POST', query: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('handles supabase errors', async () => {
+    const query = createQuery({ data: null, error: new Error('fail') })
+    const from = jest.fn(() => query)
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/services.js')
+
+    const req = { method: 'GET', query: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('salon_services')
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Failed to fetch services' }))
+  })
+
+  test('fetches services list', async () => {
+    const servicesData = [
+      { id: 1, category: 'Hair', price: 20 },
+      { id: 2, category: 'Hair', price: 30 }
+    ]
+    const query = createQuery({ data: servicesData, error: null })
+    const from = jest.fn(() => query)
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/services.js')
+
+    const req = { method: 'GET', query: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('salon_services')
+    expect(query.select).toHaveBeenCalledWith('*')
+    expect(query.order).toHaveBeenCalledWith('category')
+    expect(query.order).toHaveBeenCalledWith('price')
+    expect(query.eq).toHaveBeenCalledWith('is_active', true)
+
+    const response = res.json.mock.calls[0][0]
+    expect(response).toMatchObject({ success: true, services: servicesData })
+    expect(typeof response.timestamp).toBe('string')
+  })
+})


### PR DESCRIPTION
## Summary
- test the `/api/services` endpoint for listing services
- test the `/api/services/[id]` endpoint for fetching one service

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688667e5d2a0832aa2e1177d6f791584