### PR TITLE
Add env checks to refresh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,16 @@ Apply each SQL file in the `migrations` directory in order:
 psql $SUPABASE_URL < migrations/20240102_add_profiles_table.sql
 ```
 
+### Refreshing upcoming bookings
+
+Use the helper script to populate the `upcoming_bookings` table for the next
+week of appointments. This requires `SUPABASE_URL` and
+`SUPABASE_SERVICE_ROLE_KEY` to be set in your environment.
+
+```bash
+npm run refresh-upcoming
+```
+
 ### Authentication flow
 
 Use the `/login` and `/signup` pages to authenticate.

--- a/scripts/refresh-upcoming-bookings.js
+++ b/scripts/refresh-upcoming-bookings.js
@@ -1,5 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 
+if (!process.env.SUPABASE_URL) {
+  console.error('Missing SUPABASE_URL environment variable');
+  process.exit(1);
+}
+
+if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  console.error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable');
+  process.exit(1);
+}
+
 const supabase = createClient(
   process.env.SUPABASE_URL,
   process.env.SUPABASE_SERVICE_ROLE_KEY


### PR DESCRIPTION
## Summary
- exit early if `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` are missing
- document how to run the refresh script in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886698e5f60832a952805b89e1811db