### PR TITLE
Display upcoming bookings on staff dashboard

### DIFF
--- a/api/get-upcoming-bookings.js
+++ b/api/get-upcoming-bookings.js
@@ -1,0 +1,59 @@
+// api/get-upcoming-bookings.js
+import { createSupabaseClient } from '../utils/supabaseClient'
+import { setCorsHeaders } from '../utils/cors'
+
+const supabase = createSupabaseClient()
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'GET')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const { limit = '5' } = req.query
+    const limitNum = parseInt(limit, 10)
+    if (!Number.isFinite(limitNum) || limitNum < 1) {
+      return res.status(400).json({ error: 'Invalid limit parameter' })
+    }
+
+    const now = new Date()
+    const nextWeek = new Date()
+    nextWeek.setDate(now.getDate() + 7)
+
+    const { data: bookings, error } = await supabase
+      .from('bookings')
+      .select('*, salon_services(*)')
+      .gte('appointment_date', now.toISOString())
+      .lt('appointment_date', nextWeek.toISOString())
+      .order('appointment_date', { ascending: true })
+      .limit(limitNum)
+
+    if (error) {
+      console.error('❌ Upcoming bookings fetch error:', error)
+      return res.status(500).json({
+        error: 'Failed to fetch upcoming bookings',
+        details: error.message
+      })
+    }
+
+    res.status(200).json({
+      success: true,
+      bookings: bookings || [],
+      count: bookings?.length || 0,
+      timestamp: new Date().toISOString()
+    })
+  } catch (err) {
+    console.error('❌ Get Upcoming Bookings Error:', err)
+    res.status(500).json({
+      error: 'Unexpected error',
+      details: err.message
+    })
+  }
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -8,6 +8,7 @@ export default function StaffDashboard() {
   useRequireSupabaseAuth()
   const [metrics, setMetrics] = useState(null)
   const [branding, setBranding] = useState(null)
+  const [upcoming, setUpcoming] = useState([])
 
   useEffect(() => {
     async function load() {
@@ -22,6 +23,12 @@ export default function StaffDashboard() {
         if (mRes.ok) {
           const data = await mRes.json()
           setMetrics(data.metrics)
+        }
+
+        const uRes = await fetchWithAuth('/api/get-upcoming-bookings?limit=5')
+        if (uRes.ok) {
+          const data = await uRes.json()
+          setUpcoming(data.bookings || [])
         }
       } catch (err) {
         console.error('Dashboard load error', err)
@@ -105,6 +112,21 @@ export default function StaffDashboard() {
         <div style={{ background: '#fff3cd', padding: '20px', borderRadius: '8px', marginBottom: '30px', border: '1px solid #ffeeba' }}>
           You have {productUsageNeeded} appointments that require product usage logs.
         </div>
+
+        <h3 style={{ marginBottom: '10px' }}>Upcoming Appointments</h3>
+        {upcoming.length === 0 ? (
+          <p>No upcoming appointments.</p>
+        ) : (
+          <ul style={{ listStyle: 'none', padding: 0, marginBottom: '30px' }}>
+            {upcoming.map((apt) => (
+              <li key={apt.id} style={{ background: 'white', marginBottom: '10px', padding: '15px', borderRadius: '8px', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
+                <strong>{apt.customer_name || 'Customer'}</strong> -{' '}
+                {apt.appointment_date ? new Date(apt.appointment_date).toLocaleString() : ''}{' '}
+                {apt.salon_services?.name ? `(${apt.salon_services.name})` : ''}
+              </li>
+            ))}
+          </ul>
+        )}
 
         <h3>Quick Links</h3>
         <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>

--- a/tests/get-upcoming-bookings.test.js
+++ b/tests/get-upcoming-bookings.test.js
@@ -1,0 +1,86 @@
+// tests for api/get-upcoming-bookings.js
+const createQuery = (result) => {
+  const promise = Promise.resolve(result)
+  promise.select = jest.fn(() => promise)
+  promise.gte = jest.fn(() => promise)
+  promise.lt = jest.fn(() => promise)
+  promise.order = jest.fn(() => promise)
+  promise.limit = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function(){ return this }),
+  json: jest.fn(function(){ return this }),
+  end: jest.fn(function(){ return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  process.env.SUPABASE_URL = 'http://example.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+})
+
+describe('get-upcoming-bookings handler', () => {
+  test('returns 405 on non-GET requests', async () => {
+    const from = jest.fn(() => createQuery({ data: [], error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/get-upcoming-bookings.js')
+
+    const req = { method: 'POST', query: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('rejects invalid limit', async () => {
+    const from = jest.fn(() => createQuery({ data: [], error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/get-upcoming-bookings.js')
+
+    const req = { method: 'GET', query: { limit: '0' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid limit parameter' })
+  })
+
+  test('passes query params to supabase and returns result shape', async () => {
+    const bookingsData = [{ id: 1 }]
+    const query = createQuery({ data: bookingsData, error: null })
+    const from = jest.fn(() => query)
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/get-upcoming-bookings.js')
+
+    const req = { method: 'GET', query: { limit: '3' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(from).toHaveBeenCalledWith('bookings')
+    expect(query.select).toHaveBeenCalledWith('*, salon_services(*)')
+    expect(query.gte).toHaveBeenCalled()
+    expect(query.lt).toHaveBeenCalled()
+    expect(query.order).toHaveBeenCalledWith('appointment_date', { ascending: true })
+    expect(query.limit).toHaveBeenCalledWith(3)
+
+    const response = res.json.mock.calls[0][0]
+    expect(response).toMatchObject({
+      success: true,
+      bookings: bookingsData,
+      count: bookingsData.length
+    })
+    expect(typeof response.timestamp).toBe('string')
+  })
+})


### PR DESCRIPTION
## Summary
- add endpoint `/api/get-upcoming-bookings` to fetch next week's bookings
- show a short list of upcoming appointments on the staff dashboard
- test the new API handler

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68898a1d6aa8832a88d456c7f68ebcee