### PR TITLE
Integrate user metrics

### DIFF
--- a/api/get-dashboard-metrics.js
+++ b/api/get-dashboard-metrics.js
@@ -38,7 +38,28 @@ export default async function handler(req, res) {
     if (error) {
       throw error
     }
-    res.status(200).json({ success: true, metrics: data ? data[0] : {} })
+
+    const { data: revenueData, error: revenueError } = await supabase.rpc('total_revenue_for_user', { user_id: user.id })
+    if (revenueError) {
+      throw revenueError
+    }
+
+    const { data: appointmentData, error: appointmentError } = await supabase.rpc('total_appointments_for_user', { user_id: user.id })
+    if (appointmentError) {
+      throw appointmentError
+    }
+
+    const { data: upcomingData, error: upcomingError } = await supabase.rpc('upcoming_appointments', { user_id: user.id })
+    if (upcomingError) {
+      throw upcomingError
+    }
+
+    const metrics = data ? data[0] : {}
+    metrics.total_revenue = revenueData || []
+    metrics.appointment_counts = appointmentData || []
+    metrics.upcoming_appointments_list = upcomingData || []
+
+    res.status(200).json({ success: true, metrics })
   } catch (err) {
     console.error('Dashboard Metrics Error:', err)
     res.status(500).json({

--- a/migrations/20250104_create_user_dashboard_functions.sql
+++ b/migrations/20250104_create_user_dashboard_functions.sql
@@ -1,0 +1,48 @@
+CREATE OR REPLACE FUNCTION public.total_revenue_for_user(user_id uuid)
+RETURNS TABLE(staff_name text, total_revenue numeric) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    s.first_name || ' ' || s.last_name AS staff_name,
+    SUM(o.total_amount) AS total_revenue
+  FROM public.orders o
+  JOIN public.staff s ON s.id = o.staff_id
+  WHERE (user_id = s.user_id OR user_id = 'admin-uuid-placeholder')
+  GROUP BY s.first_name, s.last_name;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION public.total_appointments_for_user(user_id uuid)
+RETURNS TABLE(staff_name text, appointment_count integer) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    s.first_name || ' ' || s.last_name,
+    COUNT(b.id)
+  FROM public.bookings b
+  JOIN public.staff s ON s.id = b.staff_id
+  WHERE (user_id = s.user_id OR user_id = 'admin-uuid-placeholder')
+  GROUP BY s.first_name, s.last_name;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION public.upcoming_appointments(user_id uuid)
+RETURNS TABLE(staff_name text, appointment_date timestamp, customer_name text) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    s.first_name || ' ' || s.last_name,
+    b.appointment_date,
+    b.customer_name
+  FROM public.bookings b
+  JOIN public.staff s ON s.id = b.staff_id
+  WHERE 
+    (user_id = s.user_id OR user_id = 'admin-uuid-placeholder')
+    AND b.appointment_date > now()
+    AND b.status = 'scheduled'
+  ORDER BY b.appointment_date ASC;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -32,6 +32,14 @@ export default function Dashboard() {
   const ordersToday = metrics?.orders_today || 0
   const productUsageNeeded = metrics?.product_usage_needed || 0
   const lowStock = metrics?.low_stock || 0
+  const totalRevenue = (metrics?.total_revenue || []).reduce(
+    (sum, r) => sum + Number(r.total_revenue || 0),
+    0
+  )
+  const appointmentCount = (metrics?.appointment_counts || []).reduce(
+    (sum, a) => sum + Number(a.appointment_count || 0),
+    0
+  )
 
   return (
     <>
@@ -99,6 +107,28 @@ export default function Dashboard() {
           }}>
             <h3 style={{ margin: '0 0 10px', color: '#9c27b0', fontSize: '1.1em' }}>💳 Orders Today</h3>
             <p style={{ fontSize: '2.5em', margin: 0, fontWeight: 'bold', color: '#333' }}>{ordersToday}</p>
+          </div>
+          <div style={{
+            background: 'white',
+            padding: '25px',
+            borderRadius: '12px',
+            textAlign: 'center',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            border: '1px solid #e9ecef'
+          }}>
+            <h3 style={{ margin: '0 0 10px', color: '#388e3c', fontSize: '1.1em' }}>💰 Total Revenue</h3>
+            <p style={{ fontSize: '2.5em', margin: 0, fontWeight: 'bold', color: '#333' }}>${totalRevenue.toFixed(2)}</p>
+          </div>
+          <div style={{
+            background: 'white',
+            padding: '25px',
+            borderRadius: '12px',
+            textAlign: 'center',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            border: '1px solid #e9ecef'
+          }}>
+            <h3 style={{ margin: '0 0 10px', color: '#455a64', fontSize: '1.1em' }}>📋 Appointment Count</h3>
+            <p style={{ fontSize: '2.5em', margin: 0, fontWeight: 'bold', color: '#333' }}>{appointmentCount}</p>
           </div>
         </div>
 

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -23,12 +23,7 @@ export default function StaffDashboard() {
         if (mRes.ok) {
           const data = await mRes.json()
           setMetrics(data.metrics)
-        }
-
-        const uRes = await fetchWithAuth('/api/get-upcoming-bookings?limit=5')
-        if (uRes.ok) {
-          const data = await uRes.json()
-          setUpcoming(data.bookings || [])
+          setUpcoming(data.metrics.upcoming_appointments_list || [])
         }
       } catch (err) {
         console.error('Dashboard load error', err)
@@ -41,6 +36,14 @@ export default function StaffDashboard() {
   const ordersToday = metrics?.orders_today || 0
   const productUsageNeeded = metrics?.product_usage_needed || 0
   const lowStock = metrics?.low_stock || 0
+  const totalRevenue = (metrics?.total_revenue || []).reduce(
+    (sum, r) => sum + Number(r.total_revenue || 0),
+    0
+  )
+  const appointmentCount = (metrics?.appointment_counts || []).reduce(
+    (sum, a) => sum + Number(a.appointment_count || 0),
+    0
+  )
 
   return (
     <>
@@ -106,6 +109,28 @@ export default function StaffDashboard() {
           }}>
             <h3 style={{ margin: '0 0 10px', color: '#9c27b0', fontSize: '1.1em' }}>💳 Orders Today</h3>
             <p style={{ fontSize: '2.5em', margin: 0, fontWeight: 'bold', color: '#333' }}>{ordersToday}</p>
+          </div>
+          <div style={{
+            background: 'white',
+            padding: '25px',
+            borderRadius: '12px',
+            textAlign: 'center',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            border: '1px solid #e9ecef'
+          }}>
+            <h3 style={{ margin: '0 0 10px', color: '#388e3c', fontSize: '1.1em' }}>💰 Total Revenue</h3>
+            <p style={{ fontSize: '2.5em', margin: 0, fontWeight: 'bold', color: '#333' }}>${totalRevenue.toFixed(2)}</p>
+          </div>
+          <div style={{
+            background: 'white',
+            padding: '25px',
+            borderRadius: '12px',
+            textAlign: 'center',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            border: '1px solid #e9ecef'
+          }}>
+            <h3 style={{ margin: '0 0 10px', color: '#455a64', fontSize: '1.1em' }}>📋 Appointment Count</h3>
+            <p style={{ fontSize: '2.5em', margin: 0, fontWeight: 'bold', color: '#333' }}>{appointmentCount}</p>
           </div>
         </div>
 

--- a/tests/get-dashboard-metrics.test.js
+++ b/tests/get-dashboard-metrics.test.js
@@ -41,6 +41,9 @@ describe('get-dashboard-metrics handler', () => {
     await handler(req, res)
 
     expect(rpc).toHaveBeenCalledWith('dashboard_metrics', { p_staff_id: 'user1' })
+    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { user_id: 'user1' })
+    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { user_id: 'user1' })
+    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { user_id: 'user1' })
   })
 
   test('admin can request metrics for all staff', async () => {
@@ -57,5 +60,8 @@ describe('get-dashboard-metrics handler', () => {
     await handler(req, res)
 
     expect(rpc).toHaveBeenCalledWith('dashboard_metrics', { p_staff_id: null })
+    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { user_id: 'admin1' })
+    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { user_id: 'admin1' })
+    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { user_id: 'admin1' })
   })
 })


### PR DESCRIPTION
## Summary
- create SQL functions for staff revenue and appointment counts
- expose new functions via `get-dashboard-metrics` API
- display revenue and appointment count on dashboard pages
- load upcoming appointments from the same API on staff dashboard
- update tests for new RPC calls

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688abb1a9614832aa216c0f6d5f784cd