### PR TITLE
Fix Inventory tab link

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -66,7 +66,7 @@ export default function NavBar() {
         <Link href="/staff?tab=appointments" className={styles.tab}>
           📅 Appointments
         </Link>
-        <Link href="/staff?tab=inventory" className={styles.tab}>
+        <Link href="/all-products" className={styles.tab}>
           📦 Inventory
         </Link>
         <Link href="/orders" className={styles.tab}>


### PR DESCRIPTION
## Summary
- link Inventory tab in the main NavBar to the inventory list page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ad0e3975c832aa38090cdcc4e57f2