### PR TITLE
Fix Supabase client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ CREATE TABLE service_products (
 Copy `.env.example` to `.env.local` and fill in your Supabase credentials:
 
 - `SUPABASE_URL` (or `NEXT_PUBLIC_SUPABASE_URL` for the browser)
-- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY` (or rely on `SUPABASE_ANON_KEY`)
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 - `SUPABASE_STORAGE_BUCKET` (e.g., `salon-images`)
@@ -248,7 +248,7 @@ secret is currently unused unless you implement request verification.
 
 These values are required to build and run the API routes. Variables prefixed
 with `NEXT_PUBLIC_` are exposed to the browser, while server-side handlers rely
-on `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`.
+on `SUPABASE_URL` and either `SUPABASE_SERVICE_ROLE_KEY` or `SUPABASE_ANON_KEY`.
 
 ### 2. Running locally
 
@@ -311,8 +311,8 @@ psql $SUPABASE_URL < migrations/20240102_add_profiles_table.sql
 ### Refreshing upcoming bookings
 
 Use the helper script to populate the `upcoming_bookings` table for the next
-week of appointments. This requires `SUPABASE_URL` and
-`SUPABASE_SERVICE_ROLE_KEY` to be set in your environment.
+week of appointments. This requires `SUPABASE_URL` and either
+`SUPABASE_SERVICE_ROLE_KEY` or `SUPABASE_ANON_KEY` to be set in your environment.
 
 ```bash
 npm run refresh-upcoming

--- a/utils/requireAuth.js
+++ b/utils/requireAuth.js
@@ -1,7 +1,7 @@
 const { createClient } = require('@supabase/supabase-js');
 
 const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
 const supabase = supabaseUrl && supabaseKey ? createClient(supabaseUrl, supabaseKey) : null;
 
 async function requireAuth(req, res) {

--- a/utils/supabaseClient.js
+++ b/utils/supabaseClient.js
@@ -1,10 +1,12 @@
 const { createClient } = require('@supabase/supabase-js');
 
 function createSupabaseClient() {
-  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
-    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    throw new Error('Missing SUPABASE_URL or Supabase key');
   }
-  return createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  return createClient(url, key);
 }
 
 module.exports = { createSupabaseClient };


### PR DESCRIPTION
## Summary
- allow Supabase utility modules to fall back to `SUPABASE_ANON_KEY`
- document the new behaviour in the README

## Testing
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ad2aef694832abed0b7ef5f6059d0