### PR TITLE
feat: support client env for supabase

### DIFF
--- a/tests/supabaseClient.test.js
+++ b/tests/supabaseClient.test.js
@@ -1,9 +1,26 @@
 const { createSupabaseClient } = require('../utils/supabaseClient');
 
 describe('Supabase client initialization', () => {
-  it('initializes when environment variables are set', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('initializes when server environment variables are set', () => {
     process.env.SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+
+    const client = createSupabaseClient();
+    expect(client).toBeDefined();
+    expect(typeof client).toBe('object');
+  });
+
+  it('initializes when client environment variables are set', () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://public.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
 
     const client = createSupabaseClient();
     expect(client).toBeDefined();

--- a/utils/supabaseClient.js
+++ b/utils/supabaseClient.js
@@ -1,11 +1,17 @@
 const { createClient } = require('@supabase/supabase-js');
 
 function createSupabaseClient() {
-  const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+  const url =
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_ANON_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
   if (!url || !key) {
     throw new Error('Missing SUPABASE_URL or Supabase key');
   }
+
   return createClient(url, key);
 }
 


### PR DESCRIPTION
## Summary
- allow Supabase client to initialize using NEXT_PUBLIC env vars
- test Supabase client creation with server and client environment variables

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test` *(fails: SyntaxError: Cannot use import statement outside a module, Supabase client not configured)*

------
https://chatgpt.com/codex/tasks/task_e_688c22b0da2c832aacef9564d96d9457