### PR TITLE
feat: add product creation and update endpoints

### DIFF
--- a/api/update-product.js
+++ b/api/update-product.js
@@ -1,0 +1,63 @@
+import { createSupabaseClient } from '../utils/supabaseClient'
+import { setCorsHeaders } from '../utils/cors'
+
+const supabase = createSupabaseClient()
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'PATCH')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'PATCH') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const { productId, product } = req.body || {}
+    if (!productId || !product) {
+      return res
+        .status(400)
+        .json({ error: 'productId and product are required' })
+    }
+
+    const wixRes = await fetch(
+      `https://www.wixapis.com/stores/v1/products/${productId}`,
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify({ product })
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res
+        .status(wixRes.status)
+        .json({ error: 'Failed to update product', details: wixData })
+    }
+
+    const { data, error } = await supabase
+      .from('products')
+      .update({ ...product, updated_at: new Date().toISOString() })
+      .eq('wix_product_id', productId)
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Supabase product update error:', error)
+    }
+
+    res
+      .status(200)
+      .json({ success: true, product: data || wixData.product || wixData })
+  } catch (err) {
+    console.error('Update product error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/tests/create-product.test.js
+++ b/tests/create-product.test.js
@@ -1,0 +1,97 @@
+const createInsert = (result) => {
+  const promise = Promise.resolve(result)
+  promise.insert = jest.fn(() => promise)
+  promise.select = jest.fn(() => promise)
+  promise.single = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function () { return this }),
+  json: jest.fn(function () { return this }),
+  end: jest.fn(function () { return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  process.env.SUPABASE_URL = 'http://example.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+  global.fetch = jest.fn()
+})
+
+afterEach(() => {
+  delete global.fetch
+})
+
+describe('create-product handler', () => {
+  test('returns 405 on non-POST requests', async () => {
+    const from = jest.fn(() => createInsert({ data: {}, error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/create-product.js')
+
+    const req = { method: 'GET', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('validates required fields', async () => {
+    const from = jest.fn(() => createInsert({ data: {}, error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/create-product.js')
+
+    const req = { method: 'POST', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(String) })
+    )
+  })
+
+  test('calls wix API and inserts product', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ product: { id: 'p1' } })
+    })
+
+    const insertQuery = createInsert({ data: { id: '1' }, error: null })
+    const from = jest.fn(() => insertQuery)
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/create-product.js')
+
+    const reqBody = { product_name: 'T-shirt', brand: 'Nice', category: 'Apparel' }
+    const req = { method: 'POST', body: reqBody }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://www.wixapis.com/stores/v1/products',
+      expect.objectContaining({ method: 'POST', body: expect.any(String) })
+    )
+    const body = JSON.parse(fetch.mock.calls[0][1].body)
+    expect(body).toEqual({
+      product: {
+        name: 'T-shirt',
+        productType: 'physical',
+        brand: 'Nice',
+        category: 'Apparel'
+      }
+    })
+    expect(from).toHaveBeenCalledWith('products')
+    expect(insertQuery.insert).toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+})

--- a/tests/update-product.test.js
+++ b/tests/update-product.test.js
@@ -1,0 +1,91 @@
+const createUpdate = (result) => {
+  const promise = Promise.resolve(result)
+  promise.update = jest.fn(() => promise)
+  promise.eq = jest.fn(() => promise)
+  promise.select = jest.fn(() => promise)
+  promise.single = jest.fn(() => promise)
+  return promise
+}
+
+const createRes = () => ({
+  status: jest.fn(function () { return this }),
+  json: jest.fn(function () { return this }),
+  end: jest.fn(function () { return this })
+})
+
+beforeEach(() => {
+  jest.resetModules()
+  process.env.SUPABASE_URL = 'http://example.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+  global.fetch = jest.fn()
+})
+
+afterEach(() => {
+  delete global.fetch
+})
+
+describe('update-product handler', () => {
+  test('returns 405 on non-PATCH requests', async () => {
+    const from = jest.fn(() => createUpdate({ data: {}, error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/update-product.js')
+
+    const req = { method: 'GET', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(405)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Method Not Allowed' })
+  })
+
+  test('validates required fields', async () => {
+    const from = jest.fn(() => createUpdate({ data: {}, error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/update-product.js')
+
+    const req = { method: 'PATCH', body: {} }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(String) })
+    )
+  })
+
+  test('calls wix API and updates product', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ product: { id: 'p1' } })
+    })
+
+    const updateQuery = createUpdate({ data: { id: '1' }, error: null })
+    const from = jest.fn(() => updateQuery)
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+
+    const { default: handler } = await import('../api/update-product.js')
+
+    const reqBody = { productId: 'p1', product: { name: 'New' } }
+    const req = { method: 'PATCH', body: reqBody }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://www.wixapis.com/stores/v1/products/p1',
+      expect.objectContaining({ method: 'PATCH', body: expect.any(String) })
+    )
+    const body = JSON.parse(fetch.mock.calls[0][1].body)
+    expect(body).toEqual({ product: { name: 'New' } })
+    expect(from).toHaveBeenCalledWith('products')
+    expect(updateQuery.update).toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+})


### PR DESCRIPTION
## Summary
- add API route to create products via Wix API and persist data
- add product update route to patch Wix data and sync to Supabase
- add tests for product creation and update handlers

## Testing
- `npm test` *(fails: TypeError: A dynamic import callback was invoked without --experimental-vm-modules)*

------
https://chatgpt.com/codex/tasks/task_e_688d63c6af4c832a95790f5f1d40c6b4