### PR TITLE
feat: add booking management actions

### DIFF
--- a/api/bulk-confirm-or-decline-bookings.js
+++ b/api/bulk-confirm-or-decline-bookings.js
@@ -1,0 +1,36 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { details, returnEntity = false } = req.body || {}
+  if (!Array.isArray(details) || details.length === 0) {
+    return res.status(400).json({ error: 'details array is required' })
+  }
+
+  try {
+    const wixRes = await fetch(
+      'https://www.wixapis.com/bookings/v2/bulk/bookings/confirmOrDecline',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify({ details, returnEntity })
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res
+        .status(wixRes.status)
+        .json({ error: 'Failed to bulk confirm or decline', details: wixData })
+    }
+
+    res.status(200).json(wixData)
+  } catch (err) {
+    console.error('Bulk confirm/decline error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/api/bulk-create-bookings.js
+++ b/api/bulk-create-bookings.js
@@ -1,0 +1,63 @@
+import { createSupabaseClient } from '../utils/supabaseClient'
+
+const supabase = createSupabaseClient()
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { createBookingsInfo, returnFullEntity = false } = req.body || {}
+  if (!Array.isArray(createBookingsInfo) || createBookingsInfo.length === 0) {
+    return res.status(400).json({ error: 'createBookingsInfo array is required' })
+  }
+
+  try {
+    const wixRes = await fetch(
+      'https://www.wixapis.com/bookings/v2/bulk/bookings/create',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify({ createBookingsInfo, returnFullEntity })
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res
+        .status(wixRes.status)
+        .json({ error: 'Failed to bulk create bookings', details: wixData })
+    }
+
+    if (returnFullEntity && Array.isArray(wixData.results)) {
+      for (const result of wixData.results) {
+        const booking = result.item
+        if (booking?.id) {
+          await supabase
+            .from('bookings')
+            .upsert({
+              id: booking.id,
+              wix_booking_id: booking.id,
+              status: booking.status?.toLowerCase(),
+              payment_status: booking.paymentStatus?.toLowerCase(),
+              appointment_date: booking.startDate,
+              end_time: booking.endDate,
+              customer_email: booking.contactDetails?.email,
+              customer_name: `${booking.contactDetails?.firstName || ''} ${booking.contactDetails?.lastName || ''}`.trim(),
+              payload: booking,
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString()
+            }, { onConflict: 'id', ignoreDuplicates: false })
+        }
+      }
+    }
+
+    res.status(200).json(wixData)
+  } catch (err) {
+    console.error('Bulk create bookings error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/api/confirm-booking/[bookingId].js
+++ b/api/confirm-booking/[bookingId].js
@@ -1,0 +1,70 @@
+import { createSupabaseClient } from '../../utils/supabaseClient'
+
+const supabase = createSupabaseClient()
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { bookingId } = req.query
+  const {
+    revision,
+    notifyParticipants = false,
+    message,
+    sendSmsReminder,
+    paymentStatus,
+    doubleBooked,
+    flowControlSettings = {}
+  } = req.body || {}
+
+  if (!bookingId || !revision) {
+    return res.status(400).json({ error: 'bookingId and revision are required' })
+  }
+
+  try {
+    const wixRes = await fetch(
+      `https://www.wixapis.com/_api/bookings-service/v2/bookings/${bookingId}/confirm`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify({
+          revision: String(revision),
+          participantNotification: { notifyParticipants, message },
+          sendSmsReminder,
+          paymentStatus,
+          doubleBooked,
+          flowControlSettings
+        })
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res
+        .status(wixRes.status)
+        .json({ error: 'Failed to confirm booking', details: wixData })
+    }
+
+    const booking = wixData.booking || wixData
+    if (booking?.status) {
+      await supabase
+        .from('bookings')
+        .update({
+          status: booking.status?.toLowerCase(),
+          payment_status: booking.paymentStatus?.toLowerCase(),
+          revision: parseInt(booking.revision) || undefined,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', bookingId)
+    }
+
+    res.status(200).json({ success: true, booking })
+  } catch (err) {
+    console.error('Confirm booking error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/api/confirm-or-decline-booking/[bookingId].js
+++ b/api/confirm-or-decline-booking/[bookingId].js
@@ -1,0 +1,54 @@
+import { createSupabaseClient } from '../../utils/supabaseClient'
+
+const supabase = createSupabaseClient()
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { bookingId } = req.query
+  const { paymentStatus } = req.body || {}
+
+  if (!bookingId) {
+    return res.status(400).json({ error: 'bookingId is required' })
+  }
+
+  try {
+    const wixRes = await fetch(
+      `https://www.wixapis.com/bookings/v2/confirmation/${bookingId}:confirmOrDecline`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify({ paymentStatus })
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res
+        .status(wixRes.status)
+        .json({ error: 'Failed to confirm or decline booking', details: wixData })
+    }
+
+    const booking = wixData.booking || wixData
+    if (booking?.status) {
+      await supabase
+        .from('bookings')
+        .update({
+          status: booking.status?.toLowerCase(),
+          payment_status: booking.paymentStatus?.toLowerCase(),
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', bookingId)
+    }
+
+    res.status(200).json({ success: true, booking })
+  } catch (err) {
+    console.error('Confirm or decline booking error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/api/decline-booking/[bookingId].js
+++ b/api/decline-booking/[bookingId].js
@@ -1,0 +1,68 @@
+import { createSupabaseClient } from '../../utils/supabaseClient'
+
+const supabase = createSupabaseClient()
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { bookingId } = req.query
+  const {
+    revision,
+    notifyParticipants = false,
+    message,
+    paymentStatus,
+    doubleBooked,
+    flowControlSettings = {}
+  } = req.body || {}
+
+  if (!bookingId || !revision) {
+    return res.status(400).json({ error: 'bookingId and revision are required' })
+  }
+
+  try {
+    const wixRes = await fetch(
+      `https://www.wixapis.com/_api/bookings-service/v2/bookings/${bookingId}/decline`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify({
+          revision: String(revision),
+          participantNotification: { notifyParticipants, message },
+          paymentStatus,
+          doubleBooked,
+          flowControlSettings
+        })
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res
+        .status(wixRes.status)
+        .json({ error: 'Failed to decline booking', details: wixData })
+    }
+
+    const booking = wixData.booking || wixData
+    if (booking?.status) {
+      await supabase
+        .from('bookings')
+        .update({
+          status: booking.status?.toLowerCase(),
+          payment_status: booking.paymentStatus?.toLowerCase(),
+          revision: parseInt(booking.revision) || undefined,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', bookingId)
+    }
+
+    res.status(200).json({ success: true, booking })
+  } catch (err) {
+    console.error('Decline booking error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/api/update-booking-extended-fields/[bookingId].js
+++ b/api/update-booking-extended-fields/[bookingId].js
@@ -1,0 +1,40 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { bookingId } = req.query
+  const { namespace, namespaceData } = req.body || {}
+
+  if (!bookingId || !namespace || !namespaceData) {
+    return res
+      .status(400)
+      .json({ error: 'bookingId, namespace and namespaceData are required' })
+  }
+
+  try {
+    const wixRes = await fetch(
+      `https://www.wixapis.com/_api/bookings-service/v2/bookings/${bookingId}/update_extended_fields`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify({ namespace, namespaceData })
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res
+        .status(wixRes.status)
+        .json({ error: 'Failed to update extended fields', details: wixData })
+    }
+
+    res.status(200).json(wixData)
+  } catch (err) {
+    console.error('Update extended fields error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/api/update-number-of-participants/[bookingId].js
+++ b/api/update-number-of-participants/[bookingId].js
@@ -1,0 +1,58 @@
+import { createSupabaseClient } from '../../utils/supabaseClient'
+
+const supabase = createSupabaseClient()
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  const { bookingId } = req.query
+  const { revision, totalParticipants, participantsChoices } = req.body || {}
+
+  if (!bookingId || !revision || (!totalParticipants && !participantsChoices)) {
+    return res.status(400).json({ error: 'bookingId, revision and participants info are required' })
+  }
+
+  const body = { revision: String(revision) }
+  if (totalParticipants) body.totalParticipants = totalParticipants
+  if (participantsChoices) body.participantsChoices = participantsChoices
+
+  try {
+    const wixRes = await fetch(
+      `https://www.wixapis.com/_api/bookings-service/v2/bookings/${bookingId}/update_number_of_participants`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: process.env.WIX_API_TOKEN
+        },
+        body: JSON.stringify(body)
+      }
+    )
+
+    const wixData = await wixRes.json()
+    if (!wixRes.ok) {
+      return res
+        .status(wixRes.status)
+        .json({ error: 'Failed to update participants', details: wixData })
+    }
+
+    const booking = wixData.booking || wixData
+    if (booking?.totalParticipants) {
+      await supabase
+        .from('bookings')
+        .update({
+          total_participants: booking.totalParticipants,
+          revision: parseInt(booking.revision) || undefined,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', bookingId)
+    }
+
+    res.status(200).json({ success: true, booking })
+  } catch (err) {
+    console.error('Update participants error:', err)
+    res.status(500).json({ error: 'Unexpected error', details: err.message })
+  }
+}

--- a/pages/booking-details/[bookingId].js
+++ b/pages/booking-details/[bookingId].js
@@ -45,6 +45,134 @@ export default function BookingDetails() {
     }
   };
 
+  const refresh = () => loadBooking();
+
+  const handleConfirmOrDecline = async () => {
+    const paymentStatus = prompt('Payment status (e.g. PAID, NOT_PAID)', booking?.payment_status || 'PAID');
+    if (!paymentStatus) return;
+    try {
+      const res = await fetchWithAuth(`/api/confirm-or-decline-booking/${booking.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ paymentStatus })
+      });
+      if (!res.ok) throw new Error('Failed to update booking');
+      await refresh();
+    } catch (err) {
+      alert('Confirm/Decline failed');
+      console.error(err);
+    }
+  };
+
+  const handleConfirm = async () => {
+    const paymentStatus = prompt('Payment status (optional)', booking?.payment_status || '');
+    try {
+      const res = await fetchWithAuth(`/api/confirm-booking/${booking.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ revision: booking.revision, paymentStatus })
+      });
+      if (!res.ok) throw new Error('Failed to confirm booking');
+      await refresh();
+    } catch (err) {
+      alert('Confirm failed');
+      console.error(err);
+    }
+  };
+
+  const handleDecline = async () => {
+    try {
+      const res = await fetchWithAuth(`/api/decline-booking/${booking.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ revision: booking.revision })
+      });
+      if (!res.ok) throw new Error('Failed to decline booking');
+      await refresh();
+    } catch (err) {
+      alert('Decline failed');
+      console.error(err);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!confirm('Cancel this booking?')) return;
+    try {
+      const res = await fetchWithAuth(`/api/cancel-booking/${booking.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ revision: booking.revision })
+      });
+      if (!res.ok) throw new Error('Failed to cancel booking');
+      await refresh();
+    } catch (err) {
+      alert('Cancel failed');
+      console.error(err);
+    }
+  };
+
+  const handleReschedule = async () => {
+    const start = prompt('New start time (YYYY-MM-DDTHH:MM)', booking.startDate?.slice(0,16));
+    if (!start) return;
+    const end = prompt('New end time (YYYY-MM-DDTHH:MM)', booking.endDate?.slice(0,16));
+    if (!end) return;
+    try {
+      const res = await fetchWithAuth(`/api/reschedule-booking/${booking.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ startDate: new Date(start).toISOString(), endDate: new Date(end).toISOString(), revision: booking.revision })
+      });
+      if (!res.ok) throw new Error('Failed to reschedule');
+      await refresh();
+    } catch (err) {
+      alert('Reschedule failed');
+      console.error(err);
+    }
+  };
+
+  const handleUpdateParticipants = async () => {
+    const total = prompt('Total participants', booking.total_participants || booking.totalParticipants || 1);
+    if (!total) return;
+    try {
+      const res = await fetchWithAuth(`/api/update-number-of-participants/${booking.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ revision: booking.revision, totalParticipants: parseInt(total) })
+      });
+      if (!res.ok) throw new Error('Failed to update participants');
+      await refresh();
+    } catch (err) {
+      alert('Update participants failed');
+      console.error(err);
+    }
+  };
+
+  const handleUpdateExtendedFields = async () => {
+    const namespace = prompt('Namespace', '@account/app');
+    if (!namespace) return;
+    const dataStr = prompt('Namespace data (JSON)', '{"key":"value"}');
+    if (!dataStr) return;
+    let namespaceData;
+    try {
+      namespaceData = JSON.parse(dataStr);
+    } catch (e) {
+      alert('Invalid JSON');
+      return;
+    }
+    try {
+      const res = await fetchWithAuth(`/api/update-booking-extended-fields/${booking.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ namespace, namespaceData })
+      });
+      if (!res.ok) throw new Error('Failed to update extended fields');
+      alert('Extended fields updated');
+    } catch (err) {
+      alert('Update extended fields failed');
+      console.error(err);
+    }
+  };
+
   if (loading) return <p style={{padding:'20px'}}>Loading booking...</p>;
   if (error) return <p style={{padding:'20px',color:'red'}}>Error: {error}</p>;
   if (!booking) return <p style={{padding:'20px'}}>Booking not found.</p>;
@@ -55,6 +183,15 @@ export default function BookingDetails() {
       <StaffNavBar branding={branding} activeTab="appointments" />
       <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
         <h1 style={{ marginBottom: '20px' }}>Booking Details</h1>
+        <div style={{ marginBottom: '20px' }}>
+          <button onClick={handleConfirmOrDecline} style={{ marginRight: '8px' }}>Confirm/Decline</button>
+          <button onClick={handleConfirm} style={{ marginRight: '8px' }}>Confirm</button>
+          <button onClick={handleDecline} style={{ marginRight: '8px' }}>Decline</button>
+          <button onClick={handleCancel} style={{ marginRight: '8px' }}>Cancel</button>
+          <button onClick={handleReschedule} style={{ marginRight: '8px' }}>Reschedule</button>
+          <button onClick={handleUpdateParticipants} style={{ marginRight: '8px' }}>Participants</button>
+          <button onClick={handleUpdateExtendedFields}>Extended Fields</button>
+        </div>
         <table style={{ borderCollapse: 'collapse' }}>
           <tbody>
             {Object.entries(booking).map(([key, value]) => (


### PR DESCRIPTION
## Summary
- add endpoints for confirming, declining, and bulk booking operations
- expose booking action buttons for staff

## Testing
- `npm test` *(fails: A dynamic import callback was invoked without --experimental-vm-modules)*

------
https://chatgpt.com/codex/tasks/task_e_688d8cb0c56c832a9423ac3da2186f8c