### PR TITLE
feat: add schedule API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ A comprehensive webhook system for Keeping It Cute Salon that captures all busin
 - `POST /api/session-ended` - Website visitor sessions
 - `POST /api/webhook-router` - Universal fallback for any webhook
 
+### Schedules
+- `GET /api/schedules` - Query Wix schedules
+- `POST /api/schedules` - Create a new schedule
+- `GET /api/schedules/[scheduleId]` - Retrieve a schedule
+- `PATCH /api/schedules/[scheduleId]` - Update a schedule
+- `POST /api/schedules/[scheduleId]/cancel` - Cancel a schedule
+
 ### Salon Data
 - `GET /api/get-branding` - Retrieve salon branding details
 - `GET /api/get-orders` - List recent orders

--- a/api/schedules/[scheduleId].js
+++ b/api/schedules/[scheduleId].js
@@ -1,0 +1,43 @@
+import { setCorsHeaders } from '../../utils/cors'
+import { WixAPIManager } from '../../utils/wixApiManager'
+
+const wix = new WixAPIManager()
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, ['GET', 'PATCH'])
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  const { scheduleId } = req.query
+  if (!scheduleId) {
+    res.status(400).json({ error: 'scheduleId is required' })
+    return
+  }
+
+  try {
+    if (req.method === 'GET') {
+      const data = await wix.getSchedule(scheduleId)
+      res.status(200).json(data)
+      return
+    }
+
+    if (req.method === 'PATCH') {
+      const { schedule, participantNotification } = req.body || {}
+      if (!schedule) {
+        res.status(400).json({ error: 'schedule is required' })
+        return
+      }
+      const data = await wix.updateSchedule(scheduleId, schedule, participantNotification)
+      res.status(200).json(data)
+      return
+    }
+
+    res.status(405).json({ error: 'Method Not Allowed' })
+  } catch (err) {
+    console.error('Schedule detail API error:', err)
+    res.status(500).json({ error: 'Failed to process schedule request', details: err.message })
+  }
+}

--- a/api/schedules/[scheduleId]/cancel.js
+++ b/api/schedules/[scheduleId]/cancel.js
@@ -1,0 +1,33 @@
+import { setCorsHeaders } from '../../../utils/cors'
+import { WixAPIManager } from '../../../utils/wixApiManager'
+
+const wix = new WixAPIManager()
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'POST')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  const { scheduleId } = req.query
+  if (!scheduleId) {
+    res.status(400).json({ error: 'scheduleId is required' })
+    return
+  }
+
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method Not Allowed' })
+    return
+  }
+
+  try {
+    const { preserveFutureEventsWithParticipants = false, participantNotification } = req.body || {}
+    const data = await wix.cancelSchedule(scheduleId, preserveFutureEventsWithParticipants, participantNotification)
+    res.status(200).json(data)
+  } catch (err) {
+    console.error('Cancel schedule API error:', err)
+    res.status(500).json({ error: 'Failed to cancel schedule', details: err.message })
+  }
+}

--- a/api/schedules/index.js
+++ b/api/schedules/index.js
@@ -1,0 +1,42 @@
+import { setCorsHeaders } from '../utils/cors'
+import { WixAPIManager } from '../utils/wixApiManager'
+
+const wix = new WixAPIManager()
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, ['GET', 'POST'])
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  try {
+    if (req.method === 'GET') {
+      const { filter } = req.query
+      let parsedFilter = {}
+      if (filter) {
+        parsedFilter = typeof filter === 'string' ? JSON.parse(filter) : filter
+      }
+      const data = await wix.querySchedules({ filter: parsedFilter })
+      res.status(200).json(data)
+      return
+    }
+
+    if (req.method === 'POST') {
+      const { schedule, idempotencyKey } = req.body || {}
+      if (!schedule) {
+        res.status(400).json({ error: 'schedule is required' })
+        return
+      }
+      const data = await wix.createSchedule(schedule, idempotencyKey)
+      res.status(200).json(data)
+      return
+    }
+
+    res.status(405).json({ error: 'Method Not Allowed' })
+  } catch (err) {
+    console.error('Schedules API error:', err)
+    res.status(500).json({ error: 'Failed to process schedule request', details: err.message })
+  }
+}

--- a/utils/wixApiManager.js
+++ b/utils/wixApiManager.js
@@ -30,4 +30,36 @@ export class WixAPIManager {
   async getServices() {
     return this.makeRequest('/bookings/v2/services')
   }
+
+  async getSchedule(scheduleId) {
+    return this.makeRequest(`/calendar/v3/schedules/${scheduleId}`)
+  }
+
+  async querySchedules(query = {}) {
+    return this.makeRequest('/calendar/v3/schedules/query', 'POST', { query })
+  }
+
+  async createSchedule(schedule, idempotencyKey) {
+    const body = { schedule }
+    if (idempotencyKey) {
+      body.idempotencyKey = idempotencyKey
+    }
+    return this.makeRequest('/calendar/v3/schedules', 'POST', body)
+  }
+
+  async updateSchedule(scheduleId, schedule, participantNotification) {
+    const body = { schedule }
+    if (participantNotification) {
+      body.participantNotification = participantNotification
+    }
+    return this.makeRequest(`/calendar/v3/schedules/${scheduleId}`, 'PATCH', body)
+  }
+
+  async cancelSchedule(scheduleId, preserveFutureEventsWithParticipants = false, participantNotification) {
+    const body = { preserveFutureEventsWithParticipants }
+    if (participantNotification) {
+      body.participantNotification = participantNotification
+    }
+    return this.makeRequest(`/calendar/v3/schedules/${scheduleId}/cancel`, 'POST', body)
+  }
 }


### PR DESCRIPTION
## Summary
- add Wix schedule API wrappers
- expose schedule CRUD and cancel endpoints
- document schedule management API usage

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688d8e8b5cc0832aa120489a6e00aa1f