### PR TITLE
Fetch all appointments on bookings page

### DIFF
--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -19,17 +19,20 @@ export default async function handler(req, res) {
   try {
     const { page = '1', limit = '1000', status, payment_status } = req.query
 
-    const pageNum = parseInt(page, 10);
-    const limitNum = parseInt(limit, 10);
+    const pageNum = parseInt(page, 10)
+    const limitNum = parseInt(limit, 10)
     if (!Number.isFinite(pageNum) || pageNum < 1 || !Number.isFinite(limitNum) || limitNum < 1) {
-      return res.status(400).json({ error: 'Invalid page or limit parameter' });
+      return res.status(400).json({ error: 'Invalid page or limit parameter' })
     }
-    
+
+    const start = (pageNum - 1) * limitNum
+    const end = start + limitNum - 1
+
     let query = supabase
       .from('bookings')
       .select('*, salon_services(*)')
       .order('appointment_date', { ascending: false })
-      .limit(limitNum);
+      .range(start, end)
     
     if (status) {
       query = query.eq('status', status);

--- a/pages/appointments.js
+++ b/pages/appointments.js
@@ -19,10 +19,21 @@ export default function AppointmentsPage() {
   const loadAppointments = async () => {
     setLoading(true)
     try {
-      const res = await fetchWithAuth('/api/get-appointments')
-      if (!res.ok) throw new Error('Failed to load appointments')
-      const data = await res.json()
-      setAppointments(data.appointments || [])
+      const limit = 1000
+      let page = 1
+      let all = []
+
+      while (true) {
+        const res = await fetchWithAuth(`/api/get-appointments?page=${page}&limit=${limit}`)
+        if (!res.ok) throw new Error('Failed to load appointments')
+        const data = await res.json()
+        const batch = data.appointments || []
+        all = all.concat(batch)
+        if (batch.length < limit) break
+        page += 1
+      }
+
+      setAppointments(all)
       setError(null)
     } catch (err) {
       setError(err.message)

--- a/tests/get-appointments.test.js
+++ b/tests/get-appointments.test.js
@@ -53,4 +53,21 @@ describe('get-appointments handler', () => {
     expect(res.json).toHaveBeenCalledWith({ error: 'Invalid page or limit parameter' });
   });
 
+  test('applies range based on page and limit', async () => {
+    const query = createQuery({ data: [], error: null });
+    const from = jest.fn(() => query);
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+
+    const { default: handler } = await import('../api/get-appointments.js');
+
+    const req = { method: 'GET', query: { page: '2', limit: '10' } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(query.range).toHaveBeenCalledWith(10, 19);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
 });


### PR DESCRIPTION
## Summary
- paginate `/api/get-appointments` using range for accurate page fetching
- load every page of appointments on the bookings page so all records display
- add test to verify the API uses the correct range values

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688e28545e04832a9402b756a4f76e60