### PR TITLE
Restrict staff appointment visibility and add salon schedule toggle

### DIFF
--- a/api/profile.js
+++ b/api/profile.js
@@ -2,6 +2,11 @@ import { createSupabaseClient } from '../utils/supabaseClient'
 import { setCorsHeaders } from '../utils/cors'
 import requireAuth from '../utils/requireAuth'
 
+const ADMIN_IDS = (process.env.ADMIN_USER_IDS || '')
+  .split(',')
+  .map(id => id.trim())
+  .filter(Boolean)
+
 const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
@@ -26,7 +31,7 @@ export default async function handler(req, res) {
       return res.status(500).json({ error: 'Failed to load profile', details: error.message })
     }
 
-    res.status(200).json({ profile: { email: user.email, ...(data || {}) } })
+    res.status(200).json({ profile: { email: user.email, ...(data || {}), is_admin: ADMIN_IDS.includes(user.id) } })
     return
   }
 
@@ -42,7 +47,7 @@ export default async function handler(req, res) {
       return res.status(500).json({ error: 'Failed to save profile', details: error.message })
     }
 
-    res.status(200).json({ profile: data })
+    res.status(200).json({ profile: { ...data, is_admin: ADMIN_IDS.includes(user.id) } })
     return
   }
 

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -178,7 +178,7 @@ export default function StaffDashboard() {
         <h3>Quick Links</h3>
         <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
           <Link href="/product-usage-dashboard" style={{ padding: '10px 15px', background: '#e0cdbb', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>Log Product Usage</Link>
-          <Link href="/appointments" style={{ padding: '10px 15px', background: '#667eea', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>View All Appointments</Link>
+          <Link href="/appointments" style={{ padding: '10px 15px', background: '#667eea', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>Salon Schedule</Link>
           <Link href="/alerts" style={{ padding: '10px 15px', background: '#d32f2f', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>Restock Inventory</Link>
           <Link href="/site-analytics" style={{ padding: '10px 15px', background: '#1976d2', color: 'white', borderRadius: '6px', textDecoration: 'none' }}>Site Analytics</Link>
         </div>

--- a/tests/get-appointments.test.js
+++ b/tests/get-appointments.test.js
@@ -18,6 +18,7 @@ beforeEach(() => {
   jest.resetModules();
   process.env.SUPABASE_URL = 'http://example.supabase.co';
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+  process.env.ADMIN_USER_IDS = 'admin1';
 });
 
 describe('get-appointments handler', () => {
@@ -25,6 +26,7 @@ describe('get-appointments handler', () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }));
     jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' })));
 
     const { default: handler } = await import('../api/get-appointments.js');
 
@@ -41,6 +43,7 @@ describe('get-appointments handler', () => {
     const from = jest.fn(() => createQuery({ data: [], error: null }));
     jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' })));
 
     const { default: handler } = await import('../api/get-appointments.js');
 
@@ -58,6 +61,7 @@ describe('get-appointments handler', () => {
     const from = jest.fn(() => query);
     jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' })));
 
     const { default: handler } = await import('../api/get-appointments.js');
 
@@ -68,6 +72,57 @@ describe('get-appointments handler', () => {
 
     expect(query.range).toHaveBeenCalledWith(10, 19);
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('filters to user appointments for non-admins', async () => {
+    const query = createQuery({ data: [], error: null });
+    const from = jest.fn(() => query);
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' })));
+
+    const { default: handler } = await import('../api/get-appointments.js');
+
+    const req = { method: 'GET', query: { page: '1', limit: '10' } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(query.eq).toHaveBeenCalledWith('staff_id', 'user1');
+  });
+
+  test('allows viewing all appointments when scope=all', async () => {
+    const query = createQuery({ data: [], error: null });
+    const from = jest.fn(() => query);
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' })));
+
+    const { default: handler } = await import('../api/get-appointments.js');
+
+    const req = { method: 'GET', query: { page: '1', limit: '10', scope: 'all' } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(query.eq).not.toHaveBeenCalledWith('staff_id', 'user1');
+  });
+
+  test('admin can filter to their own appointments with scope=mine', async () => {
+    const query = createQuery({ data: [], error: null });
+    const from = jest.fn(() => query);
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'admin1' })));
+
+    const { default: handler } = await import('../api/get-appointments.js');
+
+    const req = { method: 'GET', query: { page: '1', limit: '10', scope: 'mine' } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(query.eq).toHaveBeenCalledWith('staff_id', 'admin1');
   });
 
 });


### PR DESCRIPTION
## Summary
- secure appointment endpoint by enforcing auth and filtering non-admins to their own bookings
- expose `is_admin` in profile API for client role checks
- add Salon Schedule toggle so staff can switch between personal and full salon views
- rename staff dashboard link to "Salon Schedule"
- extend API tests for role-based appointment filtering

## Testing
- `npm test` *(fails: Jest encountered an unexpected token and cannot parse ES modules)*
- `NODE_OPTIONS=--experimental-vm-modules npx jest --runTestsByPath tests/get-appointments.test.js` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688e8e731f78832a8286c1d65148c4eb