### PR TITLE
Fix dashboard metrics to respect staff/admin context

### DIFF
--- a/api/get-dashboard-metrics.js
+++ b/api/get-dashboard-metrics.js
@@ -8,6 +8,8 @@ const ADMIN_IDS = (process.env.ADMIN_USER_IDS || '')
   .map((id) => id.trim())
   .filter(Boolean)
 
+const ADMIN_PLACEHOLDER = 'admin-uuid-placeholder'
+
 const supabase = createSupabaseClient()
 
 export default async function handler(req, res) {
@@ -34,22 +36,25 @@ export default async function handler(req, res) {
     } else if (staffId === '' || staffId === 'null') {
       staffId = null
     }
+
+    const rpcUserId = staffId ?? ADMIN_PLACEHOLDER
+
     const { data, error } = await supabase.rpc('dashboard_metrics', { p_staff_id: staffId })
     if (error) {
       throw error
     }
 
-    const { data: revenueData, error: revenueError } = await supabase.rpc('total_revenue_for_user', { user_id: user.id })
+    const { data: revenueData, error: revenueError } = await supabase.rpc('total_revenue_for_user', { user_id: rpcUserId })
     if (revenueError) {
       throw revenueError
     }
 
-    const { data: appointmentData, error: appointmentError } = await supabase.rpc('total_appointments_for_user', { user_id: user.id })
+    const { data: appointmentData, error: appointmentError } = await supabase.rpc('total_appointments_for_user', { user_id: rpcUserId })
     if (appointmentError) {
       throw appointmentError
     }
 
-    const { data: upcomingData, error: upcomingError } = await supabase.rpc('upcoming_appointments', { user_id: user.id })
+    const { data: upcomingData, error: upcomingError } = await supabase.rpc('upcoming_appointments', { user_id: rpcUserId })
     if (upcomingError) {
       throw upcomingError
     }

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -32,7 +32,7 @@ export default function StaffDashboard() {
     load()
   }, [])
 
-  const upcomingCount = metrics?.upcoming_appointments || 0
+  const upcomingCount = upcoming.length
   const ordersToday = metrics?.orders_today || 0
   const productUsageNeeded = metrics?.product_usage_needed || 0
   const lowStock = metrics?.low_stock || 0

--- a/tests/get-dashboard-metrics.test.js
+++ b/tests/get-dashboard-metrics.test.js
@@ -60,8 +60,8 @@ describe('get-dashboard-metrics handler', () => {
     await handler(req, res)
 
     expect(rpc).toHaveBeenCalledWith('dashboard_metrics', { p_staff_id: null })
-    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { user_id: 'admin1' })
-    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { user_id: 'admin1' })
-    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { user_id: 'admin1' })
+    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { user_id: 'admin-uuid-placeholder' })
+    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { user_id: 'admin-uuid-placeholder' })
+    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { user_id: 'admin-uuid-placeholder' })
   })
 })


### PR DESCRIPTION
## Summary
- ensure dashboard metrics RPCs use the requested staff member or an admin placeholder
- count upcoming appointments from the fetched appointment list on the staff dashboard
- adjust tests for new admin placeholder behavior

## Testing
- `npm test` *(fails: A dynamic import callback was invoked without --experimental-vm-modules)*


------
https://chatgpt.com/codex/tasks/task_e_68915fc77594832a8254c43815be3293