### PR TITLE
fix: handle duplicate contacts

### DIFF
--- a/api/contact-created.js
+++ b/api/contact-created.js
@@ -31,7 +31,7 @@ export default async function handler(req, res) {
 
     const { data, error } = await supabase
       .from('contacts')
-      .insert([contactRecord])
+      .upsert(contactRecord, { onConflict: 'email' })
       .select();
 
     if (error) {


### PR DESCRIPTION
## Summary
- upsert contact records by email to avoid duplicate errors

## Testing
- `npm test` *(fails: A dynamic import callback was invoked without --experimental-vm-modules)*

------
https://chatgpt.com/codex/tasks/task_e_689167c5a5c8832a96e1350cdde48c51