### PR TITLE
feat: add wix webhook mapping functions

### DIFF
--- a/migrations/20250105_create_wix_webhook_functions.sql
+++ b/migrations/20250105_create_wix_webhook_functions.sql
@@ -1,0 +1,78 @@
+CREATE OR REPLACE FUNCTION public.process_wix_contact(payload jsonb)
+RETURNS void AS $$
+DECLARE
+  mapped jsonb;
+BEGIN
+  mapped := jsonb_build_object(
+    'wix_contact_id', payload->>'id',
+    'first_name', payload->>'firstName',
+    'last_name', payload->>'lastName',
+    'email', payload->>'primaryEmail',
+    'phone', payload->>'primaryPhone',
+    'address', payload->'addresses'->0->>'address',
+    'company_name', payload->>'company'
+  );
+
+  PERFORM generic_upsert('contacts', 'wix_contact_id', mapped);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION public.process_wix_order(payload jsonb)
+RETURNS void AS $$
+DECLARE
+  mapped jsonb;
+BEGIN
+  mapped := jsonb_build_object(
+    'wix_order_id', payload->>'id',
+    'wix_contact_id', payload->>'contactId',
+    'booking_id', payload->>'bookingId',
+    'status', payload->>'status',
+    'payment_status', payload->>'paymentStatus',
+    'currency', payload->>'currency',
+    'total_amount', payload->'totals'->>'total'
+  );
+
+  PERFORM generic_upsert('orders', 'wix_order_id', mapped);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION public.process_wix_booking(payload jsonb)
+RETURNS void AS $$
+DECLARE
+  mapped jsonb;
+BEGIN
+  mapped := jsonb_build_object(
+    'wix_booking_id', payload->>'id',
+    'wix_contact_id', payload->>'contactId',
+    'wix_order_id', payload->>'orderId',
+    'staff_member_id', COALESCE(payload->>'staffId', payload->>'resourceId'),
+    'service_id', payload->>'serviceId',
+    'appointment_date', payload->>'start',
+    'status', payload->>'status',
+    'duration_minutes', payload->>'durationInMinutes',
+    'price', payload->'price'->>'amount',
+    'notes', payload->>'notes'
+  );
+
+  PERFORM generic_upsert('bookings', 'wix_booking_id', mapped);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION public.process_wix_payment(payload jsonb)
+RETURNS void AS $$
+DECLARE
+  mapped jsonb;
+BEGIN
+  mapped := jsonb_build_object(
+    'wix_payment_id', payload->>'id',
+    'wix_order_id', payload->>'orderId',
+    'amount_paid', payload->>'amount',
+    'currency', payload->>'currency',
+    'payment_method', payload->>'method',
+    'status', payload->>'status'
+  );
+
+  PERFORM generic_upsert('wix_payments', 'wix_payment_id', mapped);
+END;
+$$ LANGUAGE plpgsql;
+


### PR DESCRIPTION
## Summary
- add auto-mapping SQL functions for contacts, orders, bookings, and payments

## Testing
- `npm test` *(fails: A dynamic import callback was invoked without --experimental-vm-modules)*

------
https://chatgpt.com/codex/tasks/task_e_6892be100c80832a9ce7e8a520a0876e