### PR TITLE
Fix appointment staff name lookup

### DIFF
--- a/api/get-appointments.js
+++ b/api/get-appointments.js
@@ -60,7 +60,7 @@ export default async function handler(req, res) {
     let userFullName = null
     try {
       const { data: profileData } = await supabase
-        .from('profiles')
+        .from('staff_profiles')
         .select('full_name')
         .eq('id', user.id)
         .single()

--- a/tests/get-appointments.test.js
+++ b/tests/get-appointments.test.js
@@ -77,7 +77,7 @@ describe('get-appointments handler', () => {
     const from = jest.fn((table) => table === 'bookings' ? query : profileQuery);
     jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
-    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' })));
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' }))); 
 
     const { default: handler } = await import('../api/get-appointments.js');
 
@@ -89,6 +89,24 @@ describe('get-appointments handler', () => {
     expect(from).toHaveBeenCalledWith('bookings');
     expect(query.range).toHaveBeenCalledWith(10, 19);
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('fetches staff profile for name filtering', async () => {
+    const query = createQuery({ data: [], error: null });
+    const profileQuery = createProfileQuery({ full_name: 'Test User' });
+    const from = jest.fn((table) => table === 'bookings' ? query : profileQuery);
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ from }) }));
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }));
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' }))); 
+
+    const { default: handler } = await import('../api/get-appointments.js');
+
+    const req = { method: 'GET', query: { page: '1', limit: '10' } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(from).toHaveBeenCalledWith('staff_profiles');
   });
 
   test('filters to user appointments for non-admins', async () => {


### PR DESCRIPTION
## Summary
- use `staff_profiles` table when resolving staff names in get-appointments
- test staff profile lookup for name filtering

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689547724238832a90d66db81c6e0407