### PR TITLE
Add logging for appointment and dashboard metrics errors

### DIFF
--- a/pages/appointments.js
+++ b/pages/appointments.js
@@ -40,7 +40,11 @@ export default function AppointmentsPage() {
       while (true) {
         const scopeQuery = scopeParam ? `&scope=${scopeParam}` : ''
         const res = await fetchWithAuth(`/api/get-appointments?page=${page}&limit=${limit}${scopeQuery}`)
-        if (!res.ok) throw new Error('Failed to load appointments')
+        if (!res.ok) {
+          const errText = await res.text().catch(() => '')
+          console.error('Appointments API error:', res.status, errText)
+          throw new Error('Failed to load appointments')
+        }
         const data = await res.json()
         const batch = data.appointments || []
         all = all.concat(batch)
@@ -51,6 +55,7 @@ export default function AppointmentsPage() {
       setAppointments(all)
       setError(null)
     } catch (err) {
+      console.error('loadAppointments error:', err)
       setError(err.message)
     } finally {
       setLoading(false)

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -15,6 +15,7 @@ export default function StaffDashboard() {
   const [appointments, setAppointments] = useState([])
   const [apptLoading, setApptLoading] = useState(false)
   const [apptError, setApptError] = useState(null)
+  const [metricsError, setMetricsError] = useState(null)
 
   const loadAppointments = async () => {
     setApptLoading(true)
@@ -148,9 +149,19 @@ export default function StaffDashboard() {
           const data = await mRes.json()
           setMetrics(data.metrics)
           setUpcoming(data.metrics.upcoming_appointments_list || [])
+          setMetricsError(null)
+        } else {
+          const errData = await mRes.json().catch(() => ({}))
+          console.error('Metrics load failed:', errData.error || mRes.status, errData.details)
+          setMetrics(null)
+          setUpcoming([])
+          setMetricsError(errData.error || 'Failed to load metrics')
         }
       } catch (err) {
         console.error('Dashboard load error', err)
+        setMetrics(null)
+        setUpcoming([])
+        setMetricsError(err.message)
       }
     }
     load()
@@ -224,6 +235,11 @@ export default function StaffDashboard() {
         </div>
 
         <h2 style={{ marginBottom: '15px' }}>Metrics at a Glance</h2>
+        {metricsError && (
+          <p style={{ color: 'red', marginBottom: '15px' }}>
+            Error loading metrics: {metricsError}
+          </p>
+        )}
         <div style={{
           display: 'grid',
           gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',


### PR DESCRIPTION
## Summary
- log API response when appointment fetch fails
- surface dashboard metrics loading errors with state and console logs

## Testing
- `npm test` *(fails: A dynamic import callback was invoked without --experimental-vm-modules, Supabase client not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68954bb6571c832abe37e763ce8a27d8