### PR TITLE
Centralize browser Supabase client and fix missing asset

### DIFF
--- a/api/get-dashboard-metrics.js
+++ b/api/get-dashboard-metrics.js
@@ -59,10 +59,13 @@ export default async function handler(req, res) {
       throw upcomingError
     }
 
-    const metrics = data ? data[0] : {}
-    metrics.total_revenue = revenueData || []
-    metrics.appointment_counts = appointmentData || []
-    metrics.upcoming_appointments_list = upcomingData || []
+    const baseMetrics = Array.isArray(data) ? data[0] : data || {}
+    const metrics = {
+      ...baseMetrics,
+      total_revenue: revenueData || [],
+      appointment_counts: appointmentData || [],
+      upcoming_appointments_list: upcomingData || []
+    }
 
     res.status(200).json({ success: true, metrics })
   } catch (err) {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react'
 import { useRouter } from 'next/router'
-import { createClient } from '@supabase/supabase-js'
 import ErrorBoundary from '../components/ErrorBoundary'
 import Layout from '../components/Layout'
+import { getBrowserSupabaseClient } from '../utils/supabaseBrowserClient'
 import '../styles/globals.css'
 
 export default function MyApp({ Component, pageProps }) {
@@ -13,12 +13,9 @@ export default function MyApp({ Component, pageProps }) {
     const hash = window.location.hash
     if (!hash || !hash.includes('access_token')) return
 
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    if (!url || !key) return
-
-    const supabase = createClient(url, key)
-    supabase.auth
+    try {
+      const supabase = getBrowserSupabaseClient()
+      supabase.auth
       .getSessionFromUrl()
       .then(({ data }) => {
         if (data?.session) {
@@ -26,6 +23,9 @@ export default function MyApp({ Component, pageProps }) {
         }
       })
       .catch(() => {})
+    } catch {
+      // missing env vars, ignore
+    }
   }, [router])
 
   return (

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,7 +21,7 @@ export default function Home() {
         <PlusIcon width={32} height={32} style={{ color: '#ff69b4' }} />
         <h1>Keeping It Cute Salon</h1>
         <Image
-          src="/glory.svg"
+          src="/images/products/nail-care/glory.svg"
           alt="Decorative graphic"
           width={300}
           height={200}

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
-import { createClient } from '@supabase/supabase-js'
+import { getBrowserSupabaseClient } from '../utils/supabaseBrowserClient'
 
 export default function Login() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -17,7 +17,7 @@ export default function Login() {
     )
   }
 
-  const supabase = createClient(supabaseUrl, supabaseAnonKey)
+  const supabase = getBrowserSupabaseClient()
 
   const router = useRouter()
   const [email, setEmail] = useState('')

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
-import { createClient } from '@supabase/supabase-js'
+import { getBrowserSupabaseClient } from '../utils/supabaseBrowserClient'
 
 export default function Signup() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -17,7 +17,7 @@ export default function Signup() {
     )
   }
 
-  const supabase = createClient(supabaseUrl, supabaseAnonKey)
+  const supabase = getBrowserSupabaseClient()
 
   const router = useRouter()
   const [email, setEmail] = useState('')

--- a/pages/staff-chat.js
+++ b/pages/staff-chat.js
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import Head from 'next/head'
-import { createClient } from '@supabase/supabase-js'
 import useRequireSupabaseAuth from '../utils/useRequireSupabaseAuth'
 import { fetchWithAuth } from '../utils/api'
+import { getBrowserSupabaseClient } from '../utils/supabaseBrowserClient'
 
 export default function StaffChat() {
   useRequireSupabaseAuth()
@@ -18,7 +18,7 @@ export default function StaffChat() {
     )
   }
 
-  const supabase = createClient(supabaseUrl, supabaseAnonKey)
+  const supabase = getBrowserSupabaseClient()
 
   const [branding, setBranding] = useState(null)
   const [messages, setMessages] = useState([])

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,11 +1,12 @@
-import { createClient } from '@supabase/supabase-js'
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+import { getBrowserSupabaseClient } from './supabaseBrowserClient'
 
 let supabase = null
-if (typeof window !== 'undefined' && supabaseUrl && anonKey) {
-  supabase = createClient(supabaseUrl, anonKey)
+if (typeof window !== 'undefined') {
+  try {
+    supabase = getBrowserSupabaseClient()
+  } catch {
+    // ignore missing env variables in non-browser environments
+  }
 }
 
 export async function fetchWithAuth(url, options = {}) {

--- a/utils/supabaseBrowserClient.js
+++ b/utils/supabaseBrowserClient.js
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js'
+
+let client = null
+
+export function getBrowserSupabaseClient() {
+  if (!client) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    if (!url || !key) {
+      throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY')
+    }
+    client = createClient(url, key)
+  }
+  return client
+}

--- a/utils/useRequireSupabaseAuth.js
+++ b/utils/useRequireSupabaseAuth.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
-import { createClient } from '@supabase/supabase-js'
+import { getBrowserSupabaseClient } from './supabaseBrowserClient'
 
 export default function useRequireSupabaseAuth() {
   const router = useRouter()
@@ -13,7 +13,13 @@ export default function useRequireSupabaseAuth() {
       return
     }
 
-    const supabase = createClient(supabaseUrl, supabaseAnonKey)
+    let supabase
+    try {
+      supabase = getBrowserSupabaseClient()
+    } catch {
+      router.replace('/login')
+      return
+    }
 
     async function checkSession() {
       if (typeof window !== 'undefined' && window.location.hash.includes('access_token')) {


### PR DESCRIPTION
## Summary
- create a shared Supabase browser client to prevent multiple GoTrueClient warnings
- update components, pages, and utils to reuse this client and adjust dashboard metrics handling
- fix homepage image path for existing glory.svg asset

## Testing
- `npm test` *(fails: A dynamic import callback was invoked without --experimental-vm-modules)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68968d230dd8832aaa8c31d80cce2245