### PR TITLE
Handle undefined staff_id in dashboard metrics

### DIFF
--- a/api/get-dashboard-metrics.js
+++ b/api/get-dashboard-metrics.js
@@ -31,9 +31,14 @@ export default async function handler(req, res) {
     const isAdmin = ADMIN_IDS.includes(user.id)
 
     let staffId = req.query.staff_id
-    if (!isAdmin || staffId === undefined) {
+    if (!isAdmin) {
       staffId = user.id
-    } else if (staffId === '' || staffId === 'null') {
+    } else if (
+      staffId === undefined ||
+      staffId === '' ||
+      staffId === 'null' ||
+      staffId === 'undefined'
+    ) {
       staffId = null
     }
 
@@ -49,7 +54,10 @@ export default async function handler(req, res) {
       throw revenueError
     }
 
-    const { data: appointmentData, error: appointmentError } = await supabase.rpc('total_appointments_for_user', { user_id: rpcUserId })
+    const { data: appointmentData, error: appointmentError } = await supabase.rpc(
+      'total_appointments_for_user',
+      { user_id: rpcUserId }
+    )
     if (appointmentError) {
       throw appointmentError
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "deploy": "vercel --prod",
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "refresh-upcoming": "node scripts/refresh-upcoming-bookings.js"
   },
   "dependencies": {

--- a/tests/get-dashboard-metrics.test.js
+++ b/tests/get-dashboard-metrics.test.js
@@ -64,4 +64,23 @@ describe('get-dashboard-metrics handler', () => {
     expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { user_id: 'admin-uuid-placeholder' })
     expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { user_id: 'admin-uuid-placeholder' })
   })
+
+  test('admin treats "undefined" staff_id as all staff', async () => {
+    const rpc = jest.fn(() => Promise.resolve({ data: [], error: null }))
+    jest.doMock('../utils/supabaseClient', () => ({ createSupabaseClient: () => ({ rpc }) }))
+    jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
+    jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'admin1' })))
+
+    const { default: handler } = await import('../api/get-dashboard-metrics.js')
+
+    const req = { method: 'GET', query: { staff_id: 'undefined' } }
+    const res = createRes()
+
+    await handler(req, res)
+
+    expect(rpc).toHaveBeenCalledWith('dashboard_metrics', { p_staff_id: null })
+    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { user_id: 'admin-uuid-placeholder' })
+    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { user_id: 'admin-uuid-placeholder' })
+    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { user_id: 'admin-uuid-placeholder' })
+  })
 })


### PR DESCRIPTION
## Summary
- Sanitize `staff_id` query by treating missing or "undefined" values as `null` for admins
- Test admin requests with `staff_id=undefined` to ensure RPC receives `null`
- Run Jest with `--experimental-vm-modules` so dynamic imports resolve in tests

## Testing
- `npm test tests/get-dashboard-metrics.test.js` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689696489e54832a8fff389712a87d38