### PR TITLE
Add role-based access controls for staff and admin views

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from 'react'
+import useRequireSupabaseAuth from '../utils/useRequireSupabaseAuth'
+import useRequireRole from '../utils/useRequireRole'
 import { fetchMetrics } from '../utils/fetchMetrics'
 
 export default function Dashboard() {
+  useRequireSupabaseAuth()
+  useRequireRole(['admin'])
   const [metrics, setMetrics] = useState(null)
 
   useEffect(() => {

--- a/pages/login.js
+++ b/pages/login.js
@@ -34,10 +34,23 @@ export default function Login() {
     const { error } = await supabase.auth.signInWithPassword({ email, password })
     if (error) {
       setError(error.message)
-    } else {
-      router.push('/staff')
+      setLoading(false)
+      return
     }
 
+    const { data: { user } } = await supabase.auth.getUser()
+    let redirect = '/staff'
+    if (user) {
+      const { data } = await supabase
+        .from('profiles')
+        .select('role')
+        .eq('id', user.id)
+        .single()
+      if (data?.role === 'admin') {
+        redirect = '/dashboard'
+      }
+    }
+    router.push(redirect)
     setLoading(false)
   }
 

--- a/pages/site-analytics.js
+++ b/pages/site-analytics.js
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react'
 import Head from 'next/head'
+import useRequireSupabaseAuth from '../utils/useRequireSupabaseAuth'
+import useRequireRole from '../utils/useRequireRole'
 import { fetchWithAuth } from '../utils/api'
 
 // Basic analytics metrics derived from the local database
@@ -11,6 +13,8 @@ const MEASUREMENTS = [
 ]
 
 export default function SiteAnalytics() {
+  useRequireSupabaseAuth()
+  useRequireRole(['admin'])
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [selected, setSelected] = useState(['TOTAL_SESSIONS'])

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -3,11 +3,13 @@ import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import useRequireSupabaseAuth from '../utils/useRequireSupabaseAuth'
+import useRequireRole from '../utils/useRequireRole'
 import { fetchWithAuth } from '../utils/api'
 import AppointmentCard from '../components/AppointmentCard'
 
 export default function StaffDashboard() {
   useRequireSupabaseAuth()
+  useRequireRole(['staff', 'admin'])
   const router = useRouter()
   const [metrics, setMetrics] = useState(null)
   const [branding, setBranding] = useState(null)

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -10,7 +10,14 @@ jest.mock('@supabase/supabase-js', () => {
           }
           return Promise.resolve({ data: null, error: new Error('Invalid token') });
         })
-      }
+      },
+      from: jest.fn(() => ({
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            single: jest.fn(() => Promise.resolve({ data: { role: 'staff' }, error: null }))
+          }))
+        }))
+      }))
     }))
   };
 });
@@ -38,6 +45,6 @@ describe('requireAuth', () => {
     await requireAuth(req, res);
 
     expect(res.end).not.toHaveBeenCalled();
-    expect(req.user).toEqual({ id: '123' });
+    expect(req.user).toEqual({ id: '123', role: 'staff' });
   });
 });

--- a/utils/requireAuth.js
+++ b/utils/requireAuth.js
@@ -27,8 +27,19 @@ async function requireAuth(req, res) {
     res.end('Unauthorized');
     return null;
   }
-  req.user = data.user;
-  return data.user;
+  let role = null;
+  try {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', data.user.id)
+      .single();
+    role = profile?.role || null;
+  } catch (e) {
+    role = null;
+  }
+  req.user = { ...data.user, role };
+  return req.user;
 }
 
 module.exports = requireAuth;

--- a/utils/useRequireRole.js
+++ b/utils/useRequireRole.js
@@ -1,0 +1,30 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { getBrowserSupabaseClient } from './supabaseBrowserClient'
+
+export default function useRequireRole(allowedRoles = []) {
+  const router = useRouter()
+
+  useEffect(() => {
+    const supabase = getBrowserSupabaseClient()
+
+    async function checkRole() {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        router.replace('/login')
+        return
+      }
+      const { data } = await supabase
+        .from('profiles')
+        .select('role')
+        .eq('id', user.id)
+        .single()
+      const role = data?.role
+      if (!allowedRoles.includes(role)) {
+        router.replace('/staff')
+      }
+    }
+
+    checkRole()
+  }, [router, allowedRoles.join(',')])
+}


### PR DESCRIPTION
## Summary
- add reusable hook to enforce role-based routing
- gate staff, dashboard, and analytics pages by user role
- redirect after login based on profile role and expose role in server-side auth

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(prompts for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689768d99940832abfa7ec40437b3101