### PR TITLE
Add role-based access controls for staff and admin views

### DIFF
--- a/api/profile.js
+++ b/api/profile.js
@@ -40,7 +40,7 @@ export default async function handler(req, res) {
       ADMIN_IDS.includes(user.id) ||
       (user.email && ADMIN_EMAILS.includes(user.email.toLowerCase()))
 
-    res.status(200).json({ profile: { email: user.email, ...(data || {}), is_admin: isAdmin } })
+    res.status(200).json({ profile: { email: user.email, role: user.role, ...(data || {}), is_admin: isAdmin } })
     return
   }
 
@@ -60,7 +60,7 @@ export default async function handler(req, res) {
       ADMIN_IDS.includes(user.id) ||
       (user.email && ADMIN_EMAILS.includes(user.email.toLowerCase()))
 
-    res.status(200).json({ profile: { ...data, is_admin: isAdmin } })
+    res.status(200).json({ profile: { ...data, role: user.role, is_admin: isAdmin } })
     return
   }
 

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from 'react'
+import useRequireSupabaseAuth from '../utils/useRequireSupabaseAuth'
+import useRequireRole from '../utils/useRequireRole'
 import { fetchMetrics } from '../utils/fetchMetrics'
 
 export default function Dashboard() {
+  useRequireSupabaseAuth()
+  useRequireRole(['admin'])
   const [metrics, setMetrics] = useState(null)
 
   useEffect(() => {

--- a/pages/login.js
+++ b/pages/login.js
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
 import { getBrowserSupabaseClient } from '../utils/supabaseBrowserClient'
+import { fetchWithAuth } from '../utils/api'
 
 export default function Login() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -34,10 +35,23 @@ export default function Login() {
     const { error } = await supabase.auth.signInWithPassword({ email, password })
     if (error) {
       setError(error.message)
-    } else {
-      router.push('/staff')
+      setLoading(false)
+      return
     }
 
+    let redirect = '/staff'
+    try {
+      const res = await fetchWithAuth('/api/profile')
+      if (res.ok) {
+        const { profile } = await res.json()
+        if (profile?.role === 'admin') {
+          redirect = '/dashboard'
+        }
+      }
+    } catch {
+      // ignore
+    }
+    router.push(redirect)
     setLoading(false)
   }
 

--- a/pages/site-analytics.js
+++ b/pages/site-analytics.js
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react'
 import Head from 'next/head'
+import useRequireSupabaseAuth from '../utils/useRequireSupabaseAuth'
+import useRequireRole from '../utils/useRequireRole'
 import { fetchWithAuth } from '../utils/api'
 
 // Basic analytics metrics derived from the local database
@@ -11,6 +13,8 @@ const MEASUREMENTS = [
 ]
 
 export default function SiteAnalytics() {
+  useRequireSupabaseAuth()
+  useRequireRole(['admin'])
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [selected, setSelected] = useState(['TOTAL_SESSIONS'])

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -3,11 +3,13 @@ import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import useRequireSupabaseAuth from '../utils/useRequireSupabaseAuth'
+import useRequireRole from '../utils/useRequireRole'
 import { fetchWithAuth } from '../utils/api'
 import AppointmentCard from '../components/AppointmentCard'
 
 export default function StaffDashboard() {
   useRequireSupabaseAuth()
+  useRequireRole(['staff', 'admin'])
   const router = useRouter()
   const [metrics, setMetrics] = useState(null)
   const [branding, setBranding] = useState(null)

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -10,7 +10,14 @@ jest.mock('@supabase/supabase-js', () => {
           }
           return Promise.resolve({ data: null, error: new Error('Invalid token') });
         })
-      }
+      },
+      from: jest.fn(() => ({
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            single: jest.fn(() => Promise.resolve({ data: { role: 'staff' }, error: null }))
+          }))
+        }))
+      }))
     }))
   };
 });
@@ -38,6 +45,6 @@ describe('requireAuth', () => {
     await requireAuth(req, res);
 
     expect(res.end).not.toHaveBeenCalled();
-    expect(req.user).toEqual({ id: '123' });
+    expect(req.user).toEqual({ id: '123', role: 'staff' });
   });
 });

--- a/utils/requireAuth.js
+++ b/utils/requireAuth.js
@@ -27,8 +27,19 @@ async function requireAuth(req, res) {
     res.end('Unauthorized');
     return null;
   }
-  req.user = data.user;
-  return data.user;
+  let role = null;
+  try {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', data.user.id)
+      .single();
+    role = profile?.role || null;
+  } catch (e) {
+    role = null;
+  }
+  req.user = { ...data.user, role };
+  return req.user;
 }
 
 module.exports = requireAuth;

--- a/utils/useRequireRole.js
+++ b/utils/useRequireRole.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { fetchWithAuth } from './api'
+
+export default function useRequireRole(allowedRoles = []) {
+  const router = useRouter()
+
+  useEffect(() => {
+    async function checkRole() {
+      try {
+        const res = await fetchWithAuth('/api/profile')
+        if (!res.ok) {
+          router.replace('/login')
+          return
+        }
+        const { profile } = await res.json()
+        const role = profile?.role
+        if (!role || !allowedRoles.includes(role)) {
+          router.replace('/staff')
+        }
+      } catch (err) {
+        router.replace('/login')
+      }
+    }
+
+    checkRole()
+  }, [router, allowedRoles.join(',')])
+}


### PR DESCRIPTION
## Summary
- add reusable hook to enforce role-based routing
- gate staff, dashboard, and analytics pages by user role
- redirect after login based on profile role and expose role in server-side auth
- avoid client-side profile queries by fetching role via authenticated API

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689768d99940832abfa7ec40437b3101