### PR TITLE
feat: add supabase utilities for pages auth

### DIFF
--- a/pages/api/auth/confirm.js
+++ b/pages/api/auth/confirm.js
@@ -1,0 +1,29 @@
+import createClient from '../../../utils/supabase/api'
+
+function stringOrFirstString(item) {
+  return Array.isArray(item) ? item[0] : item
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.status(405).setHeader('Allow', 'GET').end()
+    return
+  }
+
+  const token_hash = stringOrFirstString(req.query.token_hash)
+  const type = stringOrFirstString(req.query.type)
+  let next = '/error'
+
+  if (token_hash && type) {
+    const supabase = createClient(req, res)
+    const { error } = await supabase.auth.verifyOtp({
+      token_hash,
+      type,
+    })
+    if (!error) {
+      next = stringOrFirstString(req.query.next) || '/'
+    }
+  }
+
+  res.redirect(next)
+}

--- a/pages/error.js
+++ b/pages/error.js
@@ -1,0 +1,8 @@
+export default function ErrorPage() {
+  return (
+    <main style={{ padding: '2rem', textAlign: 'center' }}>
+      <h1>Something went wrong</h1>
+      <p>Please try again or contact support.</p>
+    </main>
+  )
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
-import { getBrowserSupabaseClient } from '../utils/supabaseBrowserClient'
+import { createClient } from '../utils/supabase/component'
 
 export default function Login() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -17,7 +17,7 @@ export default function Login() {
     )
   }
 
-  const supabase = getBrowserSupabaseClient()
+  const supabase = createClient()
 
   const router = useRouter()
   const [email, setEmail] = useState('')
@@ -41,11 +41,14 @@ export default function Login() {
     const { data: { user } } = await supabase.auth.getUser()
     let redirect = '/staff'
     if (user) {
-      const { data } = await supabase
+      const { data, error: profileError } = await supabase
         .from('profiles')
         .select('role')
         .eq('id', user.id)
-        .single()
+        .maybeSingle()
+      if (profileError) {
+        console.error(profileError)
+      }
       if (data?.role === 'admin') {
         redirect = '/dashboard'
       }

--- a/utils/supabase/api.js
+++ b/utils/supabase/api.js
@@ -1,0 +1,28 @@
+import { createServerClient, serializeCookieHeader } from '@supabase/ssr'
+
+export default function createClient(req, res) {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll() {
+          const source = req?.cookies || {}
+          return Object.keys(source).map((name) => ({
+            name,
+            value: source[name] ?? '',
+          }))
+        },
+        setAll(cookiesToSet) {
+          if (!Array.isArray(cookiesToSet) || cookiesToSet.length === 0) return
+          res.setHeader(
+            'Set-Cookie',
+            cookiesToSet.map(({ name, value, options }) =>
+              serializeCookieHeader(name, value, options)
+            )
+          )
+        },
+      },
+    }
+  )
+}

--- a/utils/supabase/component.js
+++ b/utils/supabase/component.js
@@ -1,0 +1,8 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  )
+}

--- a/utils/supabase/server-props.js
+++ b/utils/supabase/server-props.js
@@ -1,0 +1,28 @@
+import { createServerClient, serializeCookieHeader } from '@supabase/ssr'
+
+export function createClient({ req, res }) {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll() {
+          const source = req?.cookies || {}
+          return Object.keys(source).map((name) => ({
+            name,
+            value: source[name] ?? '',
+          }))
+        },
+        setAll(cookiesToSet) {
+          if (!Array.isArray(cookiesToSet) || cookiesToSet.length === 0) return
+          res.setHeader(
+            'Set-Cookie',
+            cookiesToSet.map(({ name, value, options }) =>
+              serializeCookieHeader(name, value, options)
+            )
+          )
+        },
+      },
+    }
+  )
+}

--- a/utils/supabase/static-props.js
+++ b/utils/supabase/static-props.js
@@ -1,0 +1,16 @@
+import { createServerClient } from '@supabase/ssr'
+
+export function createClient() {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll() {
+          return []
+        },
+        setAll() {},
+      },
+    }
+  )
+}


### PR DESCRIPTION
## Summary
- add cookie-aware Supabase helpers for components, server-side props, static props, and API routes
- update login to handle missing profile rows without failing
- ensure auth confirmation API route uses request/response when instantiating Supabase
- guard cookie helper against missing cookies and empty sets to prevent unnecessary headers

## Testing
- `npm test` (fails: SyntaxError: Cannot use import statement outside a module)


------
https://chatgpt.com/codex/tasks/task_e_6897ae95f744832aaf7b655a7fe6ad2a