### PR TITLE
feat: support cookie-based Supabase sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,17 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "refresh-upcoming": "node scripts/refresh-upcoming-bookings.js"
   },
-  "dependencies": {
-    "next": "^14.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@supabase/supabase-js": "^2.50.0",
-    "jsonwebtoken": "^9.0.2",
-    "nodemailer": "^6.9.8",
-    "formidable": "^3.5.1",
-    "express": "^4.18.2",
-    "cookie": "^0.6.0"
+    "dependencies": {
+      "next": "^14.0.0",
+      "react": "^18.2.0",
+      "react-dom": "^18.2.0",
+      "@supabase/supabase-js": "^2.50.0",
+      "@supabase/ssr": "^0.4.0",
+      "jsonwebtoken": "^9.0.2",
+      "nodemailer": "^6.9.8",
+      "formidable": "^3.5.1",
+      "express": "^4.18.2",
+      "cookie": "^0.6.0"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",

--- a/pages/api/auth/confirm.js
+++ b/pages/api/auth/confirm.js
@@ -10,20 +10,20 @@ export default async function handler(req, res) {
     return
   }
 
-  const token_hash = stringOrFirstString(req.query.token_hash)
-  const type = stringOrFirstString(req.query.type)
-  let next = '/error'
+    const token_hash = stringOrFirstString(req.query.token_hash)
+    const type = stringOrFirstString(req.query.type)
+    let next = '/error'
 
-  if (token_hash && type) {
-    const supabase = createClient()
-    const { error } = await supabase.auth.verifyOtp({
-      token_hash,
-      type,
-    })
-    if (!error) {
-      next = stringOrFirstString(req.query.next) || '/'
+    if (token_hash && type) {
+      const supabase = createClient(req, res)
+      const { error } = await supabase.auth.verifyOtp({
+        token_hash,
+        type, // 'email', 'recovery', 'invite', 'email_change', etc.
+      })
+      if (!error) {
+        next = stringOrFirstString(req.query.next) || '/'
+      }
     }
-  }
 
   res.redirect(next)
 }

--- a/pages/login.js
+++ b/pages/login.js
@@ -41,11 +41,11 @@ export default function Login() {
     const { data: { user } } = await supabase.auth.getUser()
     let redirect = '/staff'
     if (user) {
-      const { data } = await supabase
-        .from('profiles')
-        .select('role')
-        .eq('id', user.id)
-        .single()
+        const { data } = await supabase
+          .from('profiles')
+          .select('role')
+          .eq('id', user.id)
+          .maybeSingle()
       if (data?.role === 'admin') {
         redirect = '/dashboard'
       }

--- a/utils/supabase/api.js
+++ b/utils/supabase/api.js
@@ -1,8 +1,28 @@
-import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+import { createServerClient, serializeCookieHeader } from '@supabase/ssr'
 
-export default function createClient() {
-  return createSupabaseClient(
+export default function createClient(req, res) {
+  return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll() {
+          const source = req?.cookies || {}
+          return Object.keys(source).map((name) => ({
+            name,
+            value: source[name] ?? '',
+          }))
+        },
+        setAll(cookiesToSet) {
+          if (!Array.isArray(cookiesToSet) || cookiesToSet.length === 0) return
+          res.setHeader(
+            'Set-Cookie',
+            cookiesToSet.map(({ name, value, options }) =>
+              serializeCookieHeader(name, value, options)
+            )
+          )
+        },
+      },
+    }
   )
 }

--- a/utils/supabase/component.js
+++ b/utils/supabase/component.js
@@ -1,7 +1,7 @@
-import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+import { createBrowserClient } from '@supabase/ssr'
 
 export function createClient() {
-  return createSupabaseClient(
+  return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   )

--- a/utils/supabase/server-props.js
+++ b/utils/supabase/server-props.js
@@ -1,8 +1,28 @@
-import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+import { createServerClient, serializeCookieHeader } from '@supabase/ssr'
 
-export function createClient() {
-  return createSupabaseClient(
+export function createClient({ req, res }) {
+  return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll() {
+          const source = req?.cookies || {}
+          return Object.keys(source).map((name) => ({
+            name,
+            value: source[name] ?? '',
+          }))
+        },
+        setAll(cookiesToSet) {
+          if (!Array.isArray(cookiesToSet) || cookiesToSet.length === 0) return
+          res.setHeader(
+            'Set-Cookie',
+            cookiesToSet.map(({ name, value, options }) =>
+              serializeCookieHeader(name, value, options)
+            )
+          )
+        },
+      },
+    }
   )
 }

--- a/utils/supabase/static-props.js
+++ b/utils/supabase/static-props.js
@@ -1,8 +1,14 @@
-import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+import { createServerClient } from '@supabase/ssr'
 
 export function createClient() {
-  return createSupabaseClient(
+  return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll() { return [] },
+        setAll() {},
+      },
+    }
   )
 }


### PR DESCRIPTION
## Summary
- add cookie-aware Supabase client helpers for API routes, server-side props, static props and browser components
- verify email confirmation links while persisting refreshed tokens
- tolerate missing profile records during login with `maybeSingle`

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6897ea611c10832aa7a4583a42108088