### PR TITLE
Avoid 406 when profile record is missing

### DIFF
--- a/utils/requireAuth.js
+++ b/utils/requireAuth.js
@@ -33,7 +33,7 @@ async function requireAuth(req, res) {
       .from('profiles')
       .select('role')
       .eq('id', data.user.id)
-      .single();
+      .maybeSingle();
     role = profile?.role || null;
   } catch (e) {
     role = null;

--- a/utils/useRequireRole.js
+++ b/utils/useRequireRole.js
@@ -18,7 +18,7 @@ export default function useRequireRole(allowedRoles = []) {
         .from('profiles')
         .select('role')
         .eq('id', user.id)
-        .single()
+        .maybeSingle()
       const role = data?.role
       if (!allowedRoles.includes(role)) {
         router.replace('/staff')


### PR DESCRIPTION
## Summary
- use `maybeSingle` when loading profile role on server
- avoid 406 errors in client role check

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689922f701f8832ab04623c9d68f2b76