### PR TITLE
Fix dashboard metrics count type

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ curl -X POST -H 'Authorization: Bearer YOUR_TOKEN' \
 Create a function in Supabase that aggregates the numbers used on the business dashboard:
 
 ```sql
--- migrations/20240917_allow_null_staff_in_dashboard_metrics.sql
+-- migrations/20240918_cast_counts_to_int_in_dashboard_metrics.sql
 CREATE OR REPLACE FUNCTION dashboard_metrics(p_staff_id uuid)
 RETURNS TABLE(
   upcoming_appointments integer,
@@ -125,17 +125,17 @@ RETURNS TABLE(
 BEGIN
   RETURN QUERY
     SELECT
-      (SELECT COUNT(*) FROM bookings
+      (SELECT COUNT(*)::int FROM bookings
          WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
            AND appointment_date >= NOW()
            AND appointment_date < NOW() + INTERVAL '7 days'),
-      (SELECT COUNT(*) FROM product_usage_sessions
+      (SELECT COUNT(*)::int FROM product_usage_sessions
          WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
            AND is_completed = false),
-      (SELECT COUNT(*) FROM products
+      (SELECT COUNT(*)::int FROM products
          WHERE is_active = true
            AND current_stock <= min_threshold),
-      (SELECT COUNT(*) FROM orders
+      (SELECT COUNT(*)::int FROM orders
          WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
            AND created_at::date = CURRENT_DATE);
 END;

--- a/migrations/20240918_cast_counts_to_int_in_dashboard_metrics.sql
+++ b/migrations/20240918_cast_counts_to_int_in_dashboard_metrics.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION dashboard_metrics(p_staff_id uuid)
+RETURNS TABLE(
+  upcoming_appointments integer,
+  product_usage_needed integer,
+  low_stock integer,
+  orders_today integer
+) AS $$
+BEGIN
+  RETURN QUERY
+    SELECT
+      (SELECT COUNT(*)::int FROM bookings
+         WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
+           AND appointment_date >= NOW()
+           AND appointment_date < NOW() + INTERVAL '7 days'),
+      (SELECT COUNT(*)::int FROM product_usage_sessions
+         WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
+           AND is_completed = false),
+      (SELECT COUNT(*)::int FROM products
+         WHERE is_active = true
+           AND current_stock <= min_threshold),
+      (SELECT COUNT(*)::int FROM orders
+         WHERE (p_staff_id IS NULL OR staff_id = p_staff_id)
+           AND created_at::date = CURRENT_DATE);
+END;
+$$ LANGUAGE plpgsql STABLE;


### PR DESCRIPTION
## Summary
- Cast dashboard metric counts to integers to avoid bigint mismatch
- Document new dashboard metrics function with integer casts

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68993ac8cd08832a85782815f6268181