### PR TITLE
Refactor dashboard metrics RPC parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ curl -X POST -H 'Authorization: Bearer YOUR_TOKEN' \
 Create a function in Supabase that aggregates the numbers used on the business dashboard:
 
 ```sql
+-- migrations/20240917_allow_null_staff_in_dashboard_metrics.sql
 -- migrations/20240918_cast_counts_to_int_in_dashboard_metrics.sql
 CREATE OR REPLACE FUNCTION dashboard_metrics(p_staff_id uuid)
 RETURNS TABLE(
@@ -142,11 +143,11 @@ END;
 $$ LANGUAGE plpgsql STABLE;
 ```
 
-Additional functions provide staff-specific revenue and appointment details. Passing `NULL` for the `user_id` parameter returns metrics for all staff:
+Additional functions provide staff-specific revenue and appointment details. Passing `NULL` for the user ID parameter returns metrics for all staff:
 
 ```sql
 -- migrations/20250104_create_user_dashboard_functions.sql
-CREATE OR REPLACE FUNCTION public.total_revenue_for_user(user_id uuid)
+CREATE OR REPLACE FUNCTION public.total_revenue_for_user(p_user_id uuid)
 RETURNS TABLE(staff_name text, total_revenue numeric) AS $$
 BEGIN
   RETURN QUERY
@@ -155,7 +156,7 @@ BEGIN
     SUM(o.total_amount) AS total_revenue
   FROM public.orders o
   JOIN public.staff s ON s.id = o.staff_id
-  WHERE (user_id IS NULL OR user_id = s.user_id)
+  WHERE (p_user_id IS NULL OR p_user_id = s.user_id)
   GROUP BY s.first_name, s.last_name;
 END;
 $$ LANGUAGE plpgsql;

--- a/api/get-dashboard-metrics.js
+++ b/api/get-dashboard-metrics.js
@@ -1,7 +1,7 @@
 // api/get-dashboard-metrics.js
-import { createSupabaseClient } from '../utils/supabaseClient'
-import { setCorsHeaders } from '../utils/cors'
-import requireAuth from '../utils/requireAuth'
+const { createSupabaseClient } = require('../utils/supabaseClient')
+const { setCorsHeaders } = require('../utils/cors')
+const requireAuth = require('../utils/requireAuth')
 
 const ADMIN_IDS = (process.env.ADMIN_USER_IDS || '')
   .split(',')
@@ -10,7 +10,7 @@ const ADMIN_IDS = (process.env.ADMIN_USER_IDS || '')
 
 const supabase = createSupabaseClient()
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   setCorsHeaders(res, 'GET')
 
   if (req.method === 'OPTIONS') {
@@ -45,20 +45,20 @@ export default async function handler(req, res) {
       throw error
     }
 
-    const { data: revenueData, error: revenueError } = await supabase.rpc('total_revenue_for_user', { user_id: staffId })
+    const { data: revenueData, error: revenueError } = await supabase.rpc('total_revenue_for_user', { p_user_id: staffId })
     if (revenueError) {
       throw revenueError
     }
 
     const { data: appointmentData, error: appointmentError } = await supabase.rpc(
       'total_appointments_for_user',
-      { user_id: staffId }
+      { p_user_id: staffId }
     )
     if (appointmentError) {
       throw appointmentError
     }
 
-    const { data: upcomingData, error: upcomingError } = await supabase.rpc('upcoming_appointments', { user_id: staffId })
+    const { data: upcomingData, error: upcomingError } = await supabase.rpc('upcoming_appointments', { p_user_id: staffId })
     if (upcomingError) {
       throw upcomingError
     }
@@ -80,3 +80,6 @@ export default async function handler(req, res) {
     })
   }
 }
+
+module.exports = handler
+

--- a/migrations/20250104_create_user_dashboard_functions.sql
+++ b/migrations/20250104_create_user_dashboard_functions.sql
@@ -1,43 +1,43 @@
-CREATE OR REPLACE FUNCTION public.total_revenue_for_user(user_id uuid)
+CREATE OR REPLACE FUNCTION public.total_revenue_for_user(p_user_id uuid)
 RETURNS TABLE(staff_name text, total_revenue numeric) AS $$
 BEGIN
   RETURN QUERY
-  SELECT 
+  SELECT
     s.first_name || ' ' || s.last_name AS staff_name,
     SUM(o.total_amount) AS total_revenue
   FROM public.orders o
   JOIN public.staff s ON s.id = o.staff_id
-  WHERE (user_id IS NULL OR user_id = s.user_id)
+  WHERE (p_user_id IS NULL OR p_user_id = s.user_id)
   GROUP BY s.first_name, s.last_name;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION public.total_appointments_for_user(user_id uuid)
+CREATE OR REPLACE FUNCTION public.total_appointments_for_user(p_user_id uuid)
 RETURNS TABLE(staff_name text, appointment_count integer) AS $$
 BEGIN
   RETURN QUERY
-  SELECT 
+  SELECT
     s.first_name || ' ' || s.last_name,
     COUNT(b.id)::int
   FROM public.bookings b
   JOIN public.staff s ON s.id = b.staff_id
-  WHERE (user_id IS NULL OR user_id = s.user_id)
+  WHERE (p_user_id IS NULL OR p_user_id = s.user_id)
   GROUP BY s.first_name, s.last_name;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION public.upcoming_appointments(user_id uuid)
+CREATE OR REPLACE FUNCTION public.upcoming_appointments(p_user_id uuid)
 RETURNS TABLE(staff_name text, appointment_date timestamp, customer_name text) AS $$
 BEGIN
   RETURN QUERY
-  SELECT 
+  SELECT
     s.first_name || ' ' || s.last_name,
     b.appointment_date,
     b.customer_name
   FROM public.bookings b
   JOIN public.staff s ON s.id = b.staff_id
   WHERE
-    (user_id IS NULL OR user_id = s.user_id)
+    (p_user_id IS NULL OR p_user_id = s.user_id)
     AND b.appointment_date > now()
     AND b.status = 'scheduled'
   ORDER BY b.appointment_date ASC;

--- a/tests/get-dashboard-metrics.test.js
+++ b/tests/get-dashboard-metrics.test.js
@@ -17,7 +17,7 @@ describe('get-dashboard-metrics handler', () => {
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
     jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'u1' })))
 
-    const { default: handler } = await import('../api/get-dashboard-metrics.js')
+    const handler = require('../api/get-dashboard-metrics.js')
 
     const req = { method: 'POST', query: {} }
     const res = createRes()
@@ -33,7 +33,7 @@ describe('get-dashboard-metrics handler', () => {
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
     jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'user1' })))
 
-    const { default: handler } = await import('../api/get-dashboard-metrics.js')
+    const handler = require('../api/get-dashboard-metrics.js')
 
     const req = { method: 'GET', query: { staff_id: 'other' } }
     const res = createRes()
@@ -41,9 +41,9 @@ describe('get-dashboard-metrics handler', () => {
     await handler(req, res)
 
     expect(rpc).toHaveBeenCalledWith('dashboard_metrics', { p_staff_id: 'user1' })
-    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { user_id: 'user1' })
-    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { user_id: 'user1' })
-    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { user_id: 'user1' })
+    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { p_user_id: 'user1' })
+    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { p_user_id: 'user1' })
+    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { p_user_id: 'user1' })
   })
 
   test('admin can request metrics for all staff', async () => {
@@ -52,7 +52,7 @@ describe('get-dashboard-metrics handler', () => {
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
     jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'admin1' })))
 
-    const { default: handler } = await import('../api/get-dashboard-metrics.js')
+    const handler = require('../api/get-dashboard-metrics.js')
 
     const req = { method: 'GET', query: { staff_id: '' } }
     const res = createRes()
@@ -60,9 +60,9 @@ describe('get-dashboard-metrics handler', () => {
     await handler(req, res)
 
     expect(rpc).toHaveBeenCalledWith('dashboard_metrics', { p_staff_id: null })
-    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { user_id: null })
-    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { user_id: null })
-    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { user_id: null })
+    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { p_user_id: null })
+    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { p_user_id: null })
+    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { p_user_id: null })
   })
 
   test('admin treats "undefined" staff_id as all staff', async () => {
@@ -71,7 +71,7 @@ describe('get-dashboard-metrics handler', () => {
     jest.doMock('../utils/cors', () => ({ setCorsHeaders: jest.fn() }))
     jest.doMock('../utils/requireAuth', () => jest.fn(() => Promise.resolve({ id: 'admin1' })))
 
-    const { default: handler } = await import('../api/get-dashboard-metrics.js')
+    const handler = require('../api/get-dashboard-metrics.js')
 
     const req = { method: 'GET', query: { staff_id: 'undefined' } }
     const res = createRes()
@@ -79,8 +79,8 @@ describe('get-dashboard-metrics handler', () => {
     await handler(req, res)
 
     expect(rpc).toHaveBeenCalledWith('dashboard_metrics', { p_staff_id: null })
-    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { user_id: null })
-    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { user_id: null })
-    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { user_id: null })
+    expect(rpc).toHaveBeenCalledWith('total_revenue_for_user', { p_user_id: null })
+    expect(rpc).toHaveBeenCalledWith('total_appointments_for_user', { p_user_id: null })
+    expect(rpc).toHaveBeenCalledWith('upcoming_appointments', { p_user_id: null })
   })
 })


### PR DESCRIPTION
## Summary
- switch dashboard metrics API to CommonJS and pass `p_user_id`
- update dashboard SQL helpers to use `p_user_id`
- document and test new RPC parameters

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npx jest tests/get-dashboard-metrics.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689a93e47104832a8c459707c1ae5ed4