### PR TITLE
Expose Supabase auth error instead of redirecting

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -4,7 +4,7 @@ import useRequireRole from '../utils/useRequireRole'
 import { fetchMetrics } from '../utils/fetchMetrics'
 
 export default function Dashboard() {
-  useRequireSupabaseAuth()
+  const { authError } = useRequireSupabaseAuth()
   useRequireRole(['admin'])
   const [metrics, setMetrics] = useState(null)
 
@@ -12,6 +12,7 @@ export default function Dashboard() {
     fetchMetrics().then(setMetrics)
   }, [])
 
+  if (authError) return <div>{authError}</div>
   if (!metrics) return <div>Loading metrics...</div>
 
   return (

--- a/utils/useRequireSupabaseAuth.js
+++ b/utils/useRequireSupabaseAuth.js
@@ -1,15 +1,16 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { getBrowserSupabaseClient } from './supabaseBrowserClient'
 
 export default function useRequireSupabaseAuth() {
   const router = useRouter()
+  const [authError, setAuthError] = useState(null)
 
   useEffect(() => {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
     const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
     if (!supabaseUrl || !supabaseAnonKey) {
-      router.replace('/login')
+      setAuthError('Supabase credentials missing')
       return
     }
 
@@ -17,7 +18,7 @@ export default function useRequireSupabaseAuth() {
     try {
       supabase = getBrowserSupabaseClient()
     } catch {
-      router.replace('/login')
+      setAuthError('Supabase initialization failed')
       return
     }
 
@@ -41,5 +42,7 @@ export default function useRequireSupabaseAuth() {
     }
 
     checkSession()
-  }, [router])
+  }, [router, setAuthError])
+
+  return { authError }
 }


### PR DESCRIPTION
## Summary
- handle missing Supabase credentials without redirect loops
- surface auth error to dashboard instead of redirect

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689a9dcf14fc832aa9381091153cf705