### PR TITLE
Expose unauthorized flag for role-based access

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -5,14 +5,16 @@ import { fetchMetrics } from '../utils/fetchMetrics'
 
 export default function Dashboard() {
   const { authError } = useRequireSupabaseAuth()
-  useRequireRole(['admin'])
+  const unauthorized = useRequireRole(['admin'])
   const [metrics, setMetrics] = useState(null)
 
   useEffect(() => {
+    if (unauthorized) return
     fetchMetrics().then(setMetrics)
-  }, [])
+  }, [unauthorized])
 
   if (authError) return <div>{authError}</div>
+  if (unauthorized) return <div>Not authorized</div>
   if (!metrics) return <div>Loading metrics...</div>
 
   return (

--- a/pages/site-analytics.js
+++ b/pages/site-analytics.js
@@ -14,7 +14,7 @@ const MEASUREMENTS = [
 
 export default function SiteAnalytics() {
   useRequireSupabaseAuth()
-  useRequireRole(['admin'])
+  const unauthorized = useRequireRole(['admin'])
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [selected, setSelected] = useState(['TOTAL_SESSIONS'])
@@ -22,6 +22,7 @@ export default function SiteAnalytics() {
   const [error, setError] = useState('')
 
   const loadData = async () => {
+    if (unauthorized) return
     try {
       setError('')
       const params = new URLSearchParams()
@@ -41,12 +42,15 @@ export default function SiteAnalytics() {
   }
 
   useEffect(() => {
+    if (unauthorized) return
     loadData()
-  }, [])
+  }, [unauthorized])
 
   const toggleMeasurement = (m) => {
     setSelected((prev) => (prev.includes(m) ? prev.filter((x) => x !== m) : [...prev, m]))
   }
+
+  if (unauthorized) return <div>Not authorized</div>
 
   return (
     <>

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -9,7 +9,7 @@ import AppointmentCard from '../components/AppointmentCard'
 
 export default function StaffDashboard() {
   useRequireSupabaseAuth()
-  useRequireRole(['staff', 'admin'])
+  const unauthorized = useRequireRole(['staff', 'admin'])
   const router = useRouter()
   const [metrics, setMetrics] = useState(null)
   const [branding, setBranding] = useState(null)
@@ -35,10 +35,11 @@ export default function StaffDashboard() {
   }
 
   useEffect(() => {
+    if (unauthorized) return
     if (router.isReady && router.query.tab === 'appointments') {
       loadAppointments()
     }
-  }, [router.isReady, router.query.tab])
+  }, [router.isReady, router.query.tab, unauthorized])
 
   const completeAppointment = async (apt) => {
     if (!confirm('Mark this appointment completed?')) return
@@ -221,6 +222,8 @@ export default function StaffDashboard() {
       </>
     )
   }
+
+  if (unauthorized) return <div>Not authorized</div>
 
   return (
     <>

--- a/utils/useRequireRole.js
+++ b/utils/useRequireRole.js
@@ -1,9 +1,15 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { getBrowserSupabaseClient } from './supabaseBrowserClient'
 
+/**
+ * Hook to enforce role-based access.
+ * Returns an `unauthorized` flag when the current user's role is not allowed.
+ * Pages using this hook should check the flag and render a "Not authorized" screen.
+ */
 export default function useRequireRole(allowedRoles = []) {
   const router = useRouter()
+  const [unauthorized, setUnauthorized] = useState(false)
 
   useEffect(() => {
     const supabase = getBrowserSupabaseClient()
@@ -21,10 +27,14 @@ export default function useRequireRole(allowedRoles = []) {
         .maybeSingle()
       const role = data?.role
       if (!allowedRoles.includes(role)) {
-        router.replace('/staff')
+        setUnauthorized(true)
+      } else {
+        setUnauthorized(false)
       }
     }
 
     checkRole()
   }, [router, allowedRoles.join(',')])
+
+  return unauthorized
 }


### PR DESCRIPTION
## Summary
- Track `unauthorized` state in `useRequireRole` instead of redirecting to `/staff`
- Update staff, dashboard, and site-analytics pages to show a "Not authorized" message when the flag is set

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689a9f386b10832a886936d989098267