### PR TITLE
Handle metrics fetch errors

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -7,10 +7,14 @@ export default function Dashboard() {
   const { authError } = useRequireSupabaseAuth()
   const unauthorized = useRequireRole(['admin'])
   const [metrics, setMetrics] = useState(null)
+  const [errors, setErrors] = useState([])
 
   useEffect(() => {
     if (unauthorized) return
-    fetchMetrics().then(setMetrics)
+    fetchMetrics().then((res) => {
+      setMetrics(res.metrics)
+      setErrors(res.errors)
+    })
   }, [unauthorized])
 
   if (authError) return <div>{authError}</div>
@@ -19,6 +23,11 @@ export default function Dashboard() {
 
   return (
     <div className="p-4">
+      {errors.length > 0 && (
+        <div className="mb-4 p-2 bg-yellow-100 text-yellow-800 border border-yellow-400 rounded">
+          Warning: Some metrics could not be loaded.
+        </div>
+      )}
       <h2 className="text-xl font-bold mb-4">📈 Metrics at a Glance</h2>
       <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
         <MetricCard label="Upcoming Appointments" value={metrics.upcomingAppointments} icon="📅" />

--- a/utils/fetchMetrics.js
+++ b/utils/fetchMetrics.js
@@ -11,6 +11,7 @@ export const fetchMetrics = async () => {
     totalRevenue: 0,
     appointmentCount: 0
   }
+  const errors = []
 
   const metricMap = [
     ['metric_upcoming_appointments', 'upcomingAppointments'],
@@ -23,9 +24,13 @@ export const fetchMetrics = async () => {
 
   for (const [view, key] of metricMap) {
     const { data, error } = await supabase.from(view).select('*').limit(1).single()
-    if (error) console.error(`Failed to fetch ${view}:`, error)
-    else result[key] = data.count ?? data.total ?? data.metric_value ?? 0
+    if (error) {
+      console.error(`Failed to fetch ${view}:`, error)
+      errors.push({ view, error })
+    } else {
+      result[key] = data.count ?? data.total ?? data.metric_value ?? 0
+    }
   }
 
-  return result
+  return { metrics: result, errors }
 }


### PR DESCRIPTION
## Summary
- collect metrics fetch errors and return them along with metrics
- surface metric load errors on dashboard

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689aa21445c4832aa44dcb60aed51704