### PR TITLE
Handle dashboard loading and error states separately

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -8,18 +8,35 @@ export default function Dashboard() {
   const unauthorized = useRequireRole(['admin'])
   const [metrics, setMetrics] = useState(null)
   const [errors, setErrors] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
 
   useEffect(() => {
     if (unauthorized) return
-    fetchMetrics().then((res) => {
-      setMetrics(res.metrics)
-      setErrors(res.errors)
-    })
+    setLoading(true)
+    fetchMetrics()
+      .then((res) => {
+        setMetrics(res.metrics)
+        setErrors(res.errors)
+      })
+      .catch((err) => {
+        console.error('Failed to fetch metrics', err)
+        setError('Failed to load metrics.')
+      })
+      .finally(() => setLoading(false))
   }, [unauthorized])
 
   if (authError) return <div>{authError}</div>
   if (unauthorized) return <div>Not authorized</div>
-  if (!metrics) return <div>Loading metrics...</div>
+  if (loading)
+    return (
+      <div className="flex justify-center items-center p-4">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-gray-900 mr-2"></div>
+        Loading...
+      </div>
+    )
+  if (error) return <div className="p-4 text-red-600">{error}</div>
+  if (!metrics) return null
 
   return (
     <div className="p-4">

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { createRoot } from 'react-dom/client'
+
+jest.mock('../utils/useRequireSupabaseAuth', () => () => ({ authError: null }))
+jest.mock('../utils/useRequireRole', () => () => false)
+jest.mock('../utils/fetchMetrics')
+import { fetchMetrics } from '../utils/fetchMetrics'
+import Dashboard from '../pages/dashboard.js'
+
+let container
+let root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  root.unmount()
+  document.body.removeChild(container)
+  container = null
+})
+
+test('shows spinner while loading and displays metrics on success', async () => {
+  let resolve
+  fetchMetrics.mockReturnValue(new Promise((res) => (resolve = res)))
+
+  await act(async () => {
+    root.render(React.createElement(Dashboard))
+  })
+  expect(container.textContent).toContain('Loading...')
+
+  await act(async () => {
+    resolve({
+      metrics: {
+        upcomingAppointments: 1,
+        usageFormsNeeded: 2,
+        lowStock: 3,
+        ordersToday: 4,
+        totalRevenue: 5,
+        appointmentCount: 6,
+      },
+      errors: [],
+    })
+  })
+
+  expect(container.textContent).toContain('Upcoming Appointments')
+  expect(container.textContent).not.toContain('Loading...')
+})
+
+test('shows error message if fetching fails', async () => {
+  fetchMetrics.mockRejectedValue(new Error('fail'))
+
+  await act(async () => {
+    root.render(React.createElement(Dashboard))
+  })
+
+  // allow the rejected promise to be handled
+  await act(async () => {})
+
+  expect(container.textContent).toContain('Failed to load metrics.')
+})
+
+test('shows warning when some metrics fail', async () => {
+  fetchMetrics.mockResolvedValue({
+    metrics: {
+      upcomingAppointments: 1,
+      usageFormsNeeded: 2,
+      lowStock: 3,
+      ordersToday: 4,
+      totalRevenue: 5,
+      appointmentCount: 6,
+    },
+    errors: [{ view: 'metric_low_stock', error: 'x' }],
+  })
+
+  await act(async () => {
+    root.render(React.createElement(Dashboard))
+  })
+
+  // wait for promises
+  await act(async () => {})
+
+  expect(container.textContent).toContain('Warning: Some metrics could not be loaded.')
+})


### PR DESCRIPTION
## Summary
- track dashboard loading and error independently
- show spinner while loading and render metrics with warning on partial failures
- add tests for loading, error, and partial metrics scenarios

## Testing
- `npx jest tests/dashboard.test.js` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_689aa79c3e98832aa3e72a6dd4c19a67