### PR TITLE
fix: defer supabase client creation in fetchMetrics

### DIFF
--- a/utils/fetchMetrics.js
+++ b/utils/fetchMetrics.js
@@ -1,8 +1,7 @@
 import { createSupabaseClient } from './supabaseClient'
 
-const supabase = createSupabaseClient()
-
 export const fetchMetrics = async () => {
+  const supabase = createSupabaseClient()
   const result = {
     upcomingAppointments: 0,
     usageFormsNeeded: 0,


### PR DESCRIPTION
## Summary
- create Supabase client inside `fetchMetrics` to avoid build-time failures when env vars are missing

## Testing
- `npm run build`
- `npm test` *(fails: Jest encountered an unexpected token; Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_689ab29205e8832aaadb3f7124fad722