### PR TITLE
fix: use single Supabase client for login

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
-import { createClient } from '../utils/supabase/component'
+import { getBrowserSupabaseClient } from '../utils/supabaseBrowserClient'
 
 export default function Login() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -17,7 +17,7 @@ export default function Login() {
     )
   }
 
-  const supabase = createClient()
+  const supabase = getBrowserSupabaseClient()
 
   const router = useRouter()
   const [email, setEmail] = useState('')


### PR DESCRIPTION
## Summary
- use shared Supabase browser client on login to avoid duplicate instances

## Testing
- `npm test` *(fails: Cannot use import statement outside a module; jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bd653c634832a9ad1dc351dba3966