### PR TITLE
fix: normalize role comparison

### DIFF
--- a/utils/useRequireRole.js
+++ b/utils/useRequireRole.js
@@ -26,7 +26,9 @@ export default function useRequireRole(allowedRoles = []) {
         .eq('id', user.id)
         .maybeSingle()
       const role = data?.role
-      if (!allowedRoles.includes(role)) {
+      const allowed = allowedRoles.map(r => String(r).toLowerCase())
+      const normalizedRole = String(role || '').toLowerCase()
+      if (!allowed.includes(normalizedRole)) {
         setUnauthorized(true)
       } else {
         setUnauthorized(false)


### PR DESCRIPTION
## Summary
- handle role comparisons case-insensitively in useRequireRole

## Testing
- `npm test` (fails: SyntaxError: Cannot use import statement outside a module)
- `npm run lint` (no lint output; recommends Next.js ESLint plugin)


------
https://chatgpt.com/codex/tasks/task_e_689bdfe25418832a8c46c1d3ba597bfa