### PR TITLE
Improve Supabase auth flow and error handling

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -4,7 +4,7 @@ import useRequireRole from '../utils/useRequireRole'
 import { fetchMetrics } from '../utils/fetchMetrics'
 
 export default function Dashboard() {
-  const { authError } = useRequireSupabaseAuth()
+  const { authError, loading: authLoading } = useRequireSupabaseAuth()
   const unauthorized = useRequireRole(['admin'])
   const [metrics, setMetrics] = useState(null)
   const [errors, setErrors] = useState([])
@@ -12,7 +12,7 @@ export default function Dashboard() {
   const [error, setError] = useState(null)
 
   useEffect(() => {
-    if (unauthorized) return
+    if (unauthorized || authLoading) return
     setLoading(true)
     fetchMetrics()
       .then((res) => {
@@ -24,9 +24,16 @@ export default function Dashboard() {
         setError('Failed to load metrics.')
       })
       .finally(() => setLoading(false))
-  }, [unauthorized])
+  }, [unauthorized, authLoading])
 
   if (authError) return <div>{authError}</div>
+  if (authLoading)
+    return (
+      <div className="flex justify-center items-center p-4">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-gray-900 mr-2"></div>
+        Loading...
+      </div>
+    )
   if (unauthorized) return <div>Not authorized</div>
   if (loading)
     return (

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -4,14 +4,16 @@ import useRequireSupabaseAuth from '../utils/useRequireSupabaseAuth'
 import { fetchWithAuth } from '../utils/api'
 
 export default function Profile() {
-  useRequireSupabaseAuth()
+  const { authError, loading: authLoading } = useRequireSupabaseAuth()
   const [loading, setLoading] = useState(true)
   const [profile, setProfile] = useState(null)
   const [avatarFile, setAvatarFile] = useState(null)
   const [form, setForm] = useState({ full_name: '', phone: '', address: '', gender: '' })
   const [message, setMessage] = useState('')
 
-  useEffect(() => { loadProfile() }, [])
+  useEffect(() => {
+    if (!authLoading) loadProfile()
+  }, [authLoading])
 
   const loadProfile = async () => {
     try {
@@ -67,7 +69,10 @@ export default function Profile() {
     }
   }
 
-  if (loading) {
+  if (authError) {
+    return <p style={{ padding: '2rem' }}>{authError}</p>
+  }
+  if (authLoading || loading) {
     return <p style={{ padding: '2rem' }}>Loading profile...</p>
   }
 

--- a/utils/useRequireSupabaseAuth.js
+++ b/utils/useRequireSupabaseAuth.js
@@ -5,12 +5,14 @@ import { getBrowserSupabaseClient } from './supabaseBrowserClient'
 export default function useRequireSupabaseAuth() {
   const router = useRouter()
   const [authError, setAuthError] = useState(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
     const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
     if (!supabaseUrl || !supabaseAnonKey) {
       setAuthError('Supabase credentials missing')
+      setLoading(false)
       return
     }
 
@@ -19,30 +21,43 @@ export default function useRequireSupabaseAuth() {
       supabase = getBrowserSupabaseClient()
     } catch {
       setAuthError('Supabase initialization failed')
+      setLoading(false)
       return
     }
 
     async function checkSession() {
-      if (typeof window !== 'undefined' && window.location.hash.includes('access_token')) {
-        try {
-          const { data } = await supabase.auth.getSessionFromUrl()
-          if (data?.session) {
-            router.replace('/staff')
-            return
+      try {
+        if (typeof window !== 'undefined' && window.location.hash.includes('access_token')) {
+          try {
+            const { data } = await supabase.auth.getSessionFromUrl()
+            if (data?.session) {
+              router.replace('/staff')
+              return
+            }
+          } catch (e) {
+            // ignore parsing errors
           }
-        } catch (e) {
-          // ignore parsing errors
         }
-      }
 
-      const { data } = await supabase.auth.getSession()
-      if (!data.session) {
+        const { data, error } = await supabase.auth.getSession()
+        if (error) {
+          console.error('Auth check failed:', error)
+          router.replace('/login')
+          return
+        }
+        if (!data.session) {
+          router.replace('/login')
+        }
+      } catch (err) {
+        console.error('Auth check failed:', err)
         router.replace('/login')
+      } finally {
+        setLoading(false)
       }
     }
 
     checkSession()
-  }, [router, setAuthError])
+  }, [router])
 
-  return { authError }
+  return { authError, loading }
 }


### PR DESCRIPTION
## Summary
- prefetch routes and surface detailed errors on login
- add loading state and robust error handling to Supabase auth hook
- respect auth loading in dashboard and profile pages

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found, SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689c0668fec0832a90dc4cc7946838ae