### PR TITLE
Add Vercel analytics integration

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router'
 import NavBar from './NavBar'
+import { Analytics } from "@vercel/analytics/next"
 
 export default function Layout({ children }) {
   const router = useRouter()
@@ -10,6 +11,7 @@ export default function Layout({ children }) {
     <>
       {showNav && <NavBar />}
       <main className="container">{children}</main>
+      <Analytics />
     </>
   )
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.4.0",
     "@supabase/supabase-js": "^2.50.0",
+    "@vercel/analytics": "^1.0.0",
     "cookie": "^0.6.0",
     "express": "^4.18.2",
     "formidable": "^3.5.1",


### PR DESCRIPTION
## Summary
- add Vercel analytics package
- render Analytics component in layout

## Testing
- `npm test` (fails: dynamic import requires experimental flag)
- `npm run lint` (fails: requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_689e86f5dffc832aa75da3669922d91d