### PR TITLE
Improve staff appointments loading

### DIFF
--- a/pages/staff.js
+++ b/pages/staff.js
@@ -28,9 +28,18 @@ export default function StaffDashboard() {
       const res = await fetchWithAuth('/api/get-appointments?scope=mine')
       if (!res.ok) throw new Error('Failed to load appointments')
       const data = await res.json()
-      setAppointments(data.appointments || [])
+
+      // Debug: Log the response to see the structure
+      console.log('API Response:', data)
+
+      // The API might return data.appointments or just data directly
+      const appointments = data.appointments || data || []
+      setAppointments(appointments)
       setApptError(null)
+
+      console.log('Set appointments:', appointments.length, 'items')
     } catch (err) {
+      console.error('Load appointments error:', err)
       setApptError(err.message)
     } finally {
       setApptLoading(false)


### PR DESCRIPTION
## Summary
- enhance staff dashboard appointment loader to handle varied API responses and log debugging info

## Testing
- `npm test` *(fails: A dynamic import callback was invoked without --experimental-vm-modules)*

------
https://chatgpt.com/codex/tasks/task_e_689e98939638832a8899979f6f89dd71