### PR TITLE
fix test appointment creation by ensuring staff profile exists

### DIFF
--- a/api/create-test-appointments.js
+++ b/api/create-test-appointments.js
@@ -31,12 +31,22 @@ export default async function handler(req, res) {
         .select('full_name')
         .eq('id', user.id)
         .single()
-      
+
       if (profile?.full_name) {
         userFullName = profile.full_name
       }
     } catch (profileError) {
       console.log('Profile lookup failed, using default name')
+    }
+
+    // Ensure staff profile exists to satisfy foreign key constraint
+    try {
+      await supabase.from('staff_profiles').upsert({
+        id: user.id,
+        full_name: userFullName
+      })
+    } catch (profileUpsertError) {
+      console.log('Profile upsert failed', profileUpsertError)
     }
 
     // Create sample appointments


### PR DESCRIPTION
## Summary
- upsert staff profile before inserting test appointments to satisfy foreign key constraint

## Testing
- `npm test` *(fails: TypeError: A dynamic import callback was invoked without --experimental-vm-modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a52d013584832ab9f731a6a59955a4