### PR TITLE
Add appointment debugging endpoints and UI diagnostic tools

### DIFF
--- a/api/debug-appointments.js
+++ b/api/debug-appointments.js
@@ -1,0 +1,116 @@
+import { createSupabaseClient } from '../utils/supabaseClient'
+import { setCorsHeaders } from '../utils/cors'
+import requireAuth from '../utils/requireAuth'
+
+const supabase = createSupabaseClient()
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'GET')
+  
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+  
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const user = await requireAuth(req, res)
+    if (!user) return
+
+    console.log('🔍 Diagnosing appointments for user:', user.id, user.email)
+
+    // 1. Check total appointments in bookings table
+    const { data: allAppointments, error: allError } = await supabase
+      .from('bookings')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .limit(50)
+
+    if (allError) {
+      throw allError
+    }
+
+    // 2. Group appointments by staff_id
+    const staffGroups = {}
+    allAppointments.forEach(apt => {
+      const staffId = apt.staff_id || 'NULL'
+      if (!staffGroups[staffId]) {
+        staffGroups[staffId] = []
+      }
+      staffGroups[staffId].push(apt)
+    })
+
+    // 3. Check staff table
+    const { data: allStaff, error: staffError } = await supabase
+      .from('staff')
+      .select('id, first_name, last_name, email')
+
+    // 4. Check if user has appointments with different criteria
+    const queries = {
+      exactUserId: await supabase
+        .from('bookings')
+        .select('*')
+        .eq('staff_id', user.id)
+        .limit(10),
+      
+      byEmail: await supabase
+        .from('bookings')
+        .select('*')
+        .eq('staff_member', user.email)
+        .limit(10),
+        
+      nullStaffId: await supabase
+        .from('bookings')
+        .select('*')
+        .is('staff_id', null)
+        .limit(10)
+    }
+
+    const results = {}
+    for (const [key, query] of Object.entries(queries)) {
+      const { data, error } = await query
+      results[key] = {
+        count: data?.length || 0,
+        data: data || [],
+        error: error?.message || null
+      }
+    }
+
+    res.status(200).json({
+      success: true,
+      user: {
+        id: user.id,
+        email: user.email
+      },
+      summary: {
+        totalAppointments: allAppointments.length,
+        staffGroupCounts: Object.keys(staffGroups).map(staffId => ({
+          staffId,
+          count: staffGroups[staffId].length,
+          sampleAppointment: staffGroups[staffId][0]
+        }))
+      },
+      allStaff: allStaff || [],
+      staffError: staffError?.message || null,
+      queryResults: results,
+      sampleAppointments: allAppointments.slice(0, 5).map(apt => ({
+        id: apt.id,
+        customer_name: apt.customer_name,
+        staff_id: apt.staff_id,
+        staff_member: apt.staff_member,
+        appointment_date: apt.appointment_date,
+        status: apt.status
+      }))
+    })
+
+  } catch (err) {
+    console.error('❌ Diagnostic error:', err)
+    res.status(500).json({ 
+      error: 'Diagnostic failed', 
+      details: err.message 
+    })
+  }
+}

--- a/api/get-all-appointments.js
+++ b/api/get-all-appointments.js
@@ -1,0 +1,59 @@
+import { createSupabaseClient } from '../utils/supabaseClient'
+import { setCorsHeaders } from '../utils/cors'
+import requireAuth from '../utils/requireAuth'
+
+const supabase = createSupabaseClient()
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'GET')
+  
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+  
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  try {
+    const user = await requireAuth(req, res)
+    if (!user) return
+
+    const { limit = '100' } = req.query
+
+    console.log('📋 Fetching ALL appointments without filtering for user:', user.id)
+
+    // Get ALL appointments without any staff filtering
+    const { data: appointments, error } = await supabase
+      .from('bookings')
+      .select('*')
+      .order('appointment_date', { ascending: false })
+      .limit(parseInt(limit))
+
+    if (error) {
+      console.error('❌ Appointments fetch error:', error)
+      return res.status(500).json({
+        error: 'Failed to fetch appointments',
+        details: error.message
+      })
+    }
+
+    console.log(`✅ Found ${appointments.length} total appointments`)
+
+    res.status(200).json({
+      success: true,
+      appointments: appointments || [],
+      count: appointments?.length || 0,
+      timestamp: new Date().toISOString(),
+      note: 'This shows ALL appointments without staff filtering'
+    })
+
+  } catch (err) {
+    console.error('❌ Get All Appointments Error:', err)
+    res.status(500).json({ 
+      error: 'Unexpected error', 
+      details: err.message 
+    })
+  }
+}

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -150,6 +150,7 @@ export default function StaffDashboard() {
   // Try API endpoints with different approaches
   const tryApiEndpoints = async () => {
     const endpoints = [
+      '/api/get-all-appointments?limit=100',
       '/api/get-appointments?scope=mine&limit=100',
       '/api/get-appointments?limit=100',
       '/api/appointments?limit=100'
@@ -398,8 +399,64 @@ export default function StaffDashboard() {
               Add Test Data
             </button>
 
-            {/* Clear Test Data Button */}
+            {/* Database Diagnostic Button */}
             <button 
+              onClick={async () => {
+                try {
+                  addDebugInfo('Running database diagnostic...')
+                  const res = await fetchWithAuth('/api/debug-appointments')
+                  
+                  if (res.ok) {
+                    const data = await res.json()
+                    addDebugInfo('=== DATABASE DIAGNOSTIC RESULTS ===')
+                    addDebugInfo(`Total appointments in database: ${data.summary.totalAppointments}`)
+                    addDebugInfo(`Your user ID: ${data.user.id}`)
+                    addDebugInfo(`Your email: ${data.user.email}`)
+                    
+                    // Show staff groups
+                    data.summary.staffGroupCounts.forEach(group => {
+                      addDebugInfo(`Staff ID "${group.staffId}": ${group.count} appointments`)
+                    })
+                    
+                    // Show query results
+                    addDebugInfo(`Appointments with your exact user ID: ${data.queryResults.exactUserId.count}`)
+                    addDebugInfo(`Appointments with your email as staff_member: ${data.queryResults.byEmail.count}`)
+                    addDebugInfo(`Appointments with NULL staff_id: ${data.queryResults.nullStaffId.count}`)
+                    
+                    // Show sample appointments
+                    addDebugInfo('=== SAMPLE APPOINTMENTS ===')
+                    data.sampleAppointments.forEach((apt, i) => {
+                      addDebugInfo(`${i+1}. ${apt.customer_name} - Staff ID: ${apt.staff_id || 'NULL'} - Staff Member: ${apt.staff_member || 'NULL'}`)
+                    })
+                    
+                    // Show staff records
+                    addDebugInfo('=== STAFF RECORDS ===')
+                    data.allStaff.forEach(staff => {
+                      addDebugInfo(`${staff.first_name} ${staff.last_name} (${staff.email}) - ID: ${staff.id}`)
+                    })
+                    
+                  } else {
+                    const errorText = await res.text()
+                    addDebugInfo(`❌ Diagnostic failed: ${errorText}`)
+                  }
+                } catch (err) {
+                  addDebugInfo(`❌ Diagnostic error: ${err.message}`)
+                }
+              }}
+              style={{
+                padding: '10px 20px',
+                backgroundColor: '#9c27b0',
+                color: '#fff',
+                border: 'none',
+                borderRadius: '8px',
+                cursor: 'pointer'
+              }}
+            >
+              🔍 Database Diagnostic
+            </button>
+
+            {/* Clear Test Data Button */}
+            <button
               onClick={async () => {
                 if (!confirm('Delete all test appointments? This cannot be undone.')) return
                 


### PR DESCRIPTION
## Summary
- add `/api/debug-appointments` to inspect bookings and staff data
- add `/api/get-all-appointments` to fetch all appointments without filtering
- extend staff dashboard with database diagnostic button and new endpoint in appointment loader

## Testing
- `npm test` (fails: Cannot use import statement outside a module)
- `npm run lint` (warn: recommends adding Next.js ESLint plugin)


------
https://chatgpt.com/codex/tasks/task_e_68a53b94d390832a9d692c3aca366cc5