### PR TITLE
feat: add sync status API and dashboard

### DIFF
--- a/api/sync-status.js
+++ b/api/sync-status.js
@@ -1,0 +1,715 @@
+// api/sync-status.js - Monitor and control sync operations
+import { createSupabaseClient } from '../utils/supabaseClient'
+import { setCorsHeaders } from '../utils/cors'
+
+const supabase = createSupabaseClient()
+
+export default async function handler(req, res) {
+  setCorsHeaders(res, 'GET,POST,DELETE')
+  
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  try {
+    switch (req.method) {
+      case 'GET':
+        return await getSyncStatus(req, res)
+      case 'POST':
+        return await controlSync(req, res)
+      case 'DELETE':
+        return await resetSync(req, res)
+      default:
+        return res.status(405).json({ error: 'Method Not Allowed' })
+    }
+  } catch (error) {
+    console.error('Sync status API error:', error)
+    res.status(500).json({ error: error.message })
+  }
+}
+
+async function getSyncStatus(req, res) {
+  const { detail = 'summary' } = req.query
+  
+  try {
+    // Get overall sync health
+    const syncHealth = await getSyncHealthReport()
+    
+    if (detail === 'detailed') {
+      // Get detailed breakdown
+      const detailed = await getDetailedSyncStatus()
+      return res.json({
+        success: true,
+        sync_health: syncHealth,
+        detailed_status: detailed,
+        last_updated: new Date().toISOString()
+      })
+    }
+    
+    return res.json({
+      success: true,
+      sync_health: syncHealth,
+      last_updated: new Date().toISOString()
+    })
+    
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Failed to get sync status',
+      details: error.message
+    })
+  }
+}
+
+async function controlSync(req, res) {
+  const { action, tables, options = {} } = req.body
+  
+  try {
+    switch (action) {
+      case 'start':
+        return await startSync(req, tables, options, res)
+      case 'pause':
+        return await pauseSync(res)
+      case 'resume':
+        return await resumeSync(res)
+      case 'validate':
+        return await validateSyncIntegrity(res)
+      default:
+        return res.status(400).json({ error: 'Invalid action' })
+    }
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Sync control failed',
+      details: error.message
+    })
+  }
+}
+
+async function resetSync(req, res) {
+  const { table, confirm } = req.query
+  
+  if (confirm !== 'true') {
+    return res.status(400).json({
+      error: 'Must include ?confirm=true to reset sync status'
+    })
+  }
+  
+  try {
+    if (table && table !== 'all') {
+      // Reset specific table
+      await supabase
+        .from(table)
+        .update({ 
+          sync_status: 'pending',
+          last_synced_at: null 
+        })
+        .not('id', 'is', null)
+    } else {
+      // Reset all tables
+      const tables = ['bookings', 'contacts', 'orders', 'products', 'loyalty']
+      
+      for (const tableName of tables) {
+        try {
+          await supabase
+            .from(tableName)
+            .update({ 
+              sync_status: 'pending',
+              last_synced_at: null 
+            })
+            .not('id', 'is', null)
+        } catch (err) {
+          console.log(`Table ${tableName} doesn't have sync columns - skipping`)
+        }
+      }
+    }
+    
+    res.json({
+      success: true,
+      message: `Reset sync status for ${table || 'all tables'}`,
+      timestamp: new Date().toISOString()
+    })
+    
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Failed to reset sync status',
+      details: error.message
+    })
+  }
+}
+
+// === SYNC HEALTH REPORTING ===
+
+async function getSyncHealthReport() {
+  try {
+    // Get sync status for each table
+    const tables = ['bookings', 'contacts', 'orders', 'products']
+    const health = {}
+    
+    for (const table of tables) {
+      try {
+        const { data: tableHealth } = await supabase
+          .from(table)
+          .select('sync_status, last_synced_at')
+          .not('sync_status', 'is', null)
+        
+        if (tableHealth) {
+          const total = tableHealth.length
+          const synced = tableHealth.filter(r => r.sync_status === 'synced').length
+          const failed = tableHealth.filter(r => r.sync_status === 'failed').length
+          const pending = tableHealth.filter(r => r.sync_status === 'pending').length
+          
+          const lastSync = tableHealth
+            .map(r => r.last_synced_at)
+            .filter(Boolean)
+            .sort()
+            .pop()
+          
+          health[table] = {
+            total_records: total,
+            synced: synced,
+            failed: failed,
+            pending: pending,
+            success_rate: total > 0 ? ((synced / total) * 100).toFixed(1) : '0',
+            last_sync: lastSync,
+            status: getTableSyncStatus(synced, failed, pending, total)
+          }
+        }
+      } catch (err) {
+        health[table] = {
+          status: 'no_sync_columns',
+          message: 'Table does not have sync tracking columns'
+        }
+      }
+    }
+    
+    // Get recent sync operations
+    const { data: recentSyncs } = await supabase
+      .from('webhook_logs')
+      .select('event_type, webhook_status, logged_at, data')
+      .like('event_type', '%sync%')
+      .order('logged_at', { ascending: false })
+      .limit(5)
+    
+    return {
+      tables: health,
+      recent_operations: recentSyncs || [],
+      overall_status: calculateOverallHealth(health),
+      last_check: new Date().toISOString()
+    }
+    
+  } catch (error) {
+    throw new Error(`Failed to get sync health: ${error.message}`)
+  }
+}
+
+async function getDetailedSyncStatus() {
+  try {
+    // Get detailed relationship statistics
+    const relationshipStats = await supabase.rpc('get_relationship_stats')
+    
+    // Get sync performance metrics
+    const { data: performanceMetrics } = await supabase
+      .from('webhook_logs')
+      .select('event_type, logged_at, data')
+      .like('event_type', '%sync%')
+      .gte('logged_at', new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()) // Last 7 days
+      .order('logged_at', { ascending: false })
+    
+    // Get data quality issues
+    const qualityIssues = await getDataQualityReport()
+    
+    return {
+      relationship_stats: relationshipStats,
+      performance_metrics: performanceMetrics || [],
+      data_quality: qualityIssues,
+      generated_at: new Date().toISOString()
+    }
+    
+  } catch (error) {
+    throw new Error(`Failed to get detailed status: ${error.message}`)
+  }
+}
+
+async function getDataQualityReport() {
+  try {
+    // Check for common data quality issues
+    const issues = {}
+    
+    // Missing critical booking fields
+    const { data: missingBookingFields } = await supabase
+      .from('bookings')
+      .select('id, customer_email, service_name, appointment_date, total_price')
+      .or('customer_email.is.null,service_name.is.null,appointment_date.is.null')
+      .limit(10)
+    
+    issues.missing_booking_fields = {
+      count: missingBookingFields?.length || 0,
+      examples: missingBookingFields || []
+    }
+    
+    // Orphaned bookings (no customer link)
+    const { data: orphanedBookings } = await supabase
+      .from('bookings')
+      .select('id, customer_email, service_name')
+      .is('customer_id', null)
+      .not('customer_email', 'is', null)
+      .limit(10)
+    
+    issues.orphaned_bookings = {
+      count: orphanedBookings?.length || 0,
+      examples: orphanedBookings || []
+    }
+    
+    // Invalid dates
+    const { data: invalidDates } = await supabase
+      .from('bookings')
+      .select('id, appointment_date, end_time')
+      .or('appointment_date.is.null,end_time.lt.appointment_date')
+      .limit(10)
+    
+    issues.invalid_dates = {
+      count: invalidDates?.length || 0,
+      examples: invalidDates || []
+    }
+    
+    // Duplicate wix_booking_ids
+    const { data: duplicateBookings } = await supabase.rpc('find_duplicate_wix_bookings')
+    
+    issues.duplicate_bookings = {
+      count: duplicateBookings?.length || 0,
+      examples: duplicateBookings || []
+    }
+    
+    return issues
+    
+  } catch (error) {
+    return { error: error.message }
+  }
+}
+
+// === HELPER FUNCTIONS ===
+
+function getTableSyncStatus(synced, failed, pending, total) {
+  if (total === 0) return 'empty'
+  if (pending > 0) return 'in_progress'
+  if (failed > synced) return 'mostly_failed'
+  if (failed > 0) return 'partial_success'
+  return 'fully_synced'
+}
+
+function calculateOverallHealth(tableHealth) {
+  const tables = Object.values(tableHealth).filter(h => h.status !== 'no_sync_columns')
+  
+  if (tables.length === 0) return 'no_sync_data'
+  
+  const avgSuccessRate = tables
+    .map(t => parseFloat(t.success_rate) || 0)
+    .reduce((sum, rate) => sum + rate, 0) / tables.length
+  
+  if (avgSuccessRate >= 95) return 'excellent'
+  if (avgSuccessRate >= 85) return 'good'
+  if (avgSuccessRate >= 70) return 'fair'
+  return 'poor'
+}
+
+async function startSync(req, tables, options, res) {
+  // Trigger sync via internal API call
+  const protocol = req.headers['x-forwarded-proto'] || 'http'
+  const baseUrl = `${protocol}://${req.headers.host}`
+  const syncResponse = await fetch(`${baseUrl}/api/sync-all-wix-data`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      tables: tables || ['all'],
+      batchSize: options.batchSize || 100,
+      skipExisting: options.skipExisting !== false
+    })
+  })
+  
+  const result = await syncResponse.json()
+  
+  return res.json({
+    success: true,
+    message: 'Sync initiated',
+    sync_result: result,
+    timestamp: new Date().toISOString()
+  })
+}
+
+async function pauseSync(res) {
+  // Set sync pause flag in database
+  await supabase
+    .from('system_config')
+    .upsert({
+      key: 'sync_paused',
+      value: 'true',
+      updated_at: new Date().toISOString()
+    }, { onConflict: 'key' })
+  
+  res.json({
+    success: true,
+    message: 'Sync operations paused',
+    timestamp: new Date().toISOString()
+  })
+}
+
+async function resumeSync(res) {
+  // Remove sync pause flag
+  await supabase
+    .from('system_config')
+    .delete()
+    .eq('key', 'sync_paused')
+  
+  res.json({
+    success: true,
+    message: 'Sync operations resumed',
+    timestamp: new Date().toISOString()
+  })
+}
+
+async function validateSyncIntegrity(res) {
+  try {
+    console.log('🔍 Running comprehensive sync validation...')
+    
+    // Run validation queries
+    const validation = {
+      relationship_integrity: await checkRelationshipIntegrity(),
+      data_completeness: await checkDataCompleteness(),
+      duplicate_detection: await checkForDuplicates(),
+      date_consistency: await checkDateConsistency(),
+      business_logic_validation: await validateBusinessLogic()
+    }
+    
+    const overallScore = calculateValidationScore(validation)
+    
+    res.json({
+      success: true,
+      validation_score: overallScore,
+      validation_results: validation,
+      recommendations: generateRecommendations(validation),
+      validated_at: new Date().toISOString()
+    })
+    
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: 'Validation failed',
+      details: error.message
+    })
+  }
+}
+
+// === VALIDATION FUNCTIONS ===
+
+async function checkRelationshipIntegrity() {
+  const { data: bookingRelationships } = await supabase.rpc('check_booking_relationships')
+  const { data: orderRelationships } = await supabase.rpc('check_order_relationships')
+  
+  return {
+    bookings: bookingRelationships || { customer_link_rate: 0, service_link_rate: 0, staff_link_rate: 0 },
+    orders: orderRelationships || { customer_link_rate: 0 },
+    status: (bookingRelationships?.customer_link_rate || 0) > 90 ? 'good' : 'needs_attention'
+  }
+}
+
+async function checkDataCompleteness() {
+  // Check for missing critical fields
+  const { data: missingFields } = await supabase.rpc('check_missing_critical_fields')
+  
+  return {
+    missing_fields_report: missingFields || [],
+    status: (missingFields?.length || 0) < 50 ? 'good' : 'needs_attention'
+  }
+}
+
+async function checkForDuplicates() {
+  const { data: duplicateBookings } = await supabase.rpc('find_duplicate_bookings')
+  const { data: duplicateContacts } = await supabase.rpc('find_duplicate_contacts')
+  
+  return {
+    duplicate_bookings: duplicateBookings?.length || 0,
+    duplicate_contacts: duplicateContacts?.length || 0,
+    status: ((duplicateBookings?.length || 0) + (duplicateContacts?.length || 0)) === 0 ? 'good' : 'needs_cleanup'
+  }
+}
+
+async function checkDateConsistency() {
+  const { data: invalidDates } = await supabase
+    .from('bookings')
+    .select('id, appointment_date, end_time, service_duration')
+    .or('appointment_date.is.null,end_time.lt.appointment_date')
+    .limit(100)
+  
+  return {
+    invalid_dates_count: invalidDates?.length || 0,
+    examples: invalidDates?.slice(0, 5) || [],
+    status: (invalidDates?.length || 0) === 0 ? 'good' : 'needs_fixing'
+  }
+}
+
+async function validateBusinessLogic() {
+  // Check business rule compliance
+  const issues = []
+  
+  // Bookings without prices
+  const { count: noPriceBookings } = await supabase
+    .from('bookings')
+    .select('*', { count: 'exact', head: true })
+    .is('total_price', null)
+    .neq('status', 'cancelled')
+  
+  if (noPriceBookings > 0) {
+    issues.push({
+      type: 'missing_prices',
+      count: noPriceBookings,
+      severity: 'high',
+      description: 'Active bookings without prices'
+    })
+  }
+  
+  // Future appointments without staff
+  const { count: noStaffBookings } = await supabase
+    .from('bookings')
+    .select('*', { count: 'exact', head: true })
+    .is('staff_id', null)
+    .gte('appointment_date', new Date().toISOString())
+    .neq('status', 'cancelled')
+  
+  if (noStaffBookings > 0) {
+    issues.push({
+      type: 'unassigned_staff',
+      count: noStaffBookings,
+      severity: 'medium',
+      description: 'Future appointments without staff assignment'
+    })
+  }
+  
+  // Orders without payment status
+  const { count: noPaymentStatus } = await supabase
+    .from('orders')
+    .select('*', { count: 'exact', head: true })
+    .is('payment_status', null)
+  
+  if (noPaymentStatus > 0) {
+    issues.push({
+      type: 'missing_payment_status',
+      count: noPaymentStatus,
+      severity: 'medium',
+      description: 'Orders without payment status'
+    })
+  }
+  
+  return {
+    issues: issues,
+    status: issues.length === 0 ? 'good' : 'has_issues'
+  }
+}
+
+function calculateValidationScore(validation) {
+  let score = 100
+  
+  // Deduct points for issues
+  Object.entries(validation).forEach(([category, result]) => {
+    if (result.status === 'needs_attention') {
+      score -= 15
+    } else if (result.status === 'needs_cleanup' || result.status === 'needs_fixing') {
+      score -= 10
+    } else if (result.status === 'has_issues') {
+      score -= 5
+    }
+  })
+  
+  return Math.max(0, score)
+}
+
+function generateRecommendations(validation) {
+  const recommendations = []
+  
+  if (validation.relationship_integrity?.status === 'needs_attention') {
+    recommendations.push({
+      priority: 'high',
+      action: 'Fix relationship linking',
+      description: 'Run cleanup scripts to link orphaned records',
+      sql: `
+        -- Link orphaned bookings to customers
+        UPDATE bookings SET customer_id = c.id
+        FROM contacts c 
+        WHERE bookings.customer_id IS NULL 
+          AND bookings.customer_email = c.email;
+      `
+    })
+  }
+  
+  if (validation.duplicate_detection?.status === 'needs_cleanup') {
+    recommendations.push({
+      priority: 'medium',
+      action: 'Remove duplicates',
+      description: 'Clean up duplicate records',
+      sql: `
+        -- Remove duplicate bookings (keep most recent)
+        DELETE FROM bookings b1 
+        WHERE EXISTS (
+          SELECT 1 FROM bookings b2 
+          WHERE b2.wix_booking_id = b1.wix_booking_id 
+            AND b2.id > b1.id
+        );
+      `
+    })
+  }
+  
+  if (validation.date_consistency?.status === 'needs_fixing') {
+    recommendations.push({
+      priority: 'medium',
+      action: 'Fix date inconsistencies',
+      description: 'Correct invalid appointment dates and end times',
+      sql: `
+        -- Calculate missing end times
+        UPDATE bookings 
+        SET end_time = appointment_date + (service_duration || ' minutes')::INTERVAL
+        WHERE end_time IS NULL 
+          AND appointment_date IS NOT NULL 
+          AND service_duration IS NOT NULL;
+      `
+    })
+  }
+  
+  if (validation.business_logic_validation?.issues?.length > 0) {
+    validation.business_logic_validation.issues.forEach(issue => {
+      recommendations.push({
+        priority: issue.severity,
+        action: `Address ${issue.type}`,
+        description: issue.description,
+        count: issue.count
+      })
+    })
+  }
+  
+  return recommendations
+}
+
+// === SQL HELPER FUNCTIONS (Create these in Supabase) ===
+
+/*
+Run these functions in your Supabase SQL editor:
+
+-- Function to check booking relationships
+CREATE OR REPLACE FUNCTION check_booking_relationships()
+RETURNS TABLE(
+  customer_link_rate NUMERIC,
+  service_link_rate NUMERIC,
+  staff_link_rate NUMERIC,
+  total_bookings BIGINT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    ROUND(COUNT(customer_id)::NUMERIC / COUNT(*) * 100, 1) as customer_link_rate,
+    ROUND(COUNT(service_id)::NUMERIC / COUNT(*) * 100, 1) as service_link_rate,
+    ROUND(COUNT(staff_id)::NUMERIC / COUNT(*) * 100, 1) as staff_link_rate,
+    COUNT(*) as total_bookings
+  FROM bookings 
+  WHERE sync_status = 'synced';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to check order relationships  
+CREATE OR REPLACE FUNCTION check_order_relationships()
+RETURNS TABLE(
+  customer_link_rate NUMERIC,
+  total_orders BIGINT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    ROUND(COUNT(customer_id)::NUMERIC / COUNT(*) * 100, 1) as customer_link_rate,
+    COUNT(*) as total_orders
+  FROM orders 
+  WHERE sync_status = 'synced';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to find duplicate bookings
+CREATE OR REPLACE FUNCTION find_duplicate_bookings()
+RETURNS TABLE(
+  wix_booking_id TEXT,
+  duplicate_count BIGINT,
+  booking_ids INTEGER[]
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    b.wix_booking_id,
+    COUNT(*) as duplicate_count,
+    ARRAY_AGG(b.id) as booking_ids
+  FROM bookings b
+  WHERE b.wix_booking_id IS NOT NULL
+  GROUP BY b.wix_booking_id
+  HAVING COUNT(*) > 1
+  ORDER BY duplicate_count DESC;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to find duplicate contacts
+CREATE OR REPLACE FUNCTION find_duplicate_contacts()
+RETURNS TABLE(
+  email TEXT,
+  duplicate_count BIGINT,
+  contact_ids TEXT[]
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    c.email,
+    COUNT(*) as duplicate_count,
+    ARRAY_AGG(c.id::TEXT) as contact_ids
+  FROM contacts c
+  WHERE c.email IS NOT NULL
+  GROUP BY c.email
+  HAVING COUNT(*) > 1
+  ORDER BY duplicate_count DESC;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to check missing critical fields
+CREATE OR REPLACE FUNCTION check_missing_critical_fields()
+RETURNS TABLE(
+  table_name TEXT,
+  field_name TEXT,
+  missing_count BIGINT,
+  total_count BIGINT,
+  missing_percentage NUMERIC
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    'bookings'::TEXT as table_name,
+    'customer_email'::TEXT as field_name,
+    COUNT(*) FILTER (WHERE customer_email IS NULL) as missing_count,
+    COUNT(*) as total_count,
+    ROUND(COUNT(*) FILTER (WHERE customer_email IS NULL)::NUMERIC / COUNT(*) * 100, 1) as missing_percentage
+  FROM bookings
+  
+  UNION ALL
+  
+  SELECT 
+    'bookings'::TEXT,
+    'service_name'::TEXT,
+    COUNT(*) FILTER (WHERE service_name IS NULL),
+    COUNT(*),
+    ROUND(COUNT(*) FILTER (WHERE service_name IS NULL)::NUMERIC / COUNT(*) * 100, 1)
+  FROM bookings
+  
+  UNION ALL
+  
+  SELECT 
+    'bookings'::TEXT,
+    'appointment_date'::TEXT,
+    COUNT(*) FILTER (WHERE appointment_date IS NULL),
+    COUNT(*),
+    ROUND(COUNT(*) FILTER (WHERE appointment_date IS NULL)::NUMERIC / COUNT(*) * 100, 1)
+  FROM bookings;
+END;
+$$ LANGUAGE plpgsql;
+*/

--- a/public/sync-dashboard.html
+++ b/public/sync-dashboard.html
@@ -1,0 +1,571 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wix Sync Management Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        .status-excellent { @apply bg-green-100 text-green-800 border-green-200; }
+        .status-good { @apply bg-blue-100 text-blue-800 border-blue-200; }
+        .status-fair { @apply bg-yellow-100 text-yellow-800 border-yellow-200; }
+        .status-poor { @apply bg-red-100 text-red-800 border-red-200; }
+    </style>
+</head>
+<body class="bg-gray-50 min-h-screen">
+    <div class="container mx-auto px-4 py-8 max-w-6xl">
+        <!-- Header -->
+        <div class="mb-8">
+            <h1 class="text-3xl font-bold text-gray-900 mb-2">Wix ↔ Supabase Sync Manager</h1>
+            <p class="text-gray-600">Manage and monitor your data synchronization between Wix and Supabase</p>
+        </div>
+
+        <!-- Sync Status Overview -->
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+            <div class="bg-white rounded-lg shadow p-6">
+                <div class="flex items-center">
+                    <div class="p-2 bg-blue-100 rounded-lg">
+                        <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+                        </svg>
+                    </div>
+                    <div class="ml-4">
+                        <p class="text-sm font-medium text-gray-600">Sync Health</p>
+                        <p id="sync-health" class="text-2xl font-semibold text-gray-900">Loading...</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bg-white rounded-lg shadow p-6">
+                <div class="flex items-center">
+                    <div class="p-2 bg-green-100 rounded-lg">
+                        <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                    </div>
+                    <div class="ml-4">
+                        <p class="text-sm font-medium text-gray-600">Records Synced</p>
+                        <p id="records-synced" class="text-2xl font-semibold text-gray-900">0</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bg-white rounded-lg shadow p-6">
+                <div class="flex items-center">
+                    <div class="p-2 bg-yellow-100 rounded-lg">
+                        <svg class="w-6 h-6 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.098 16.5c-.77.833.192 2.5 1.732 2.5z"></path>
+                        </svg>
+                    </div>
+                    <div class="ml-4">
+                        <p class="text-sm font-medium text-gray-600">Issues Found</p>
+                        <p id="issues-count" class="text-2xl font-semibold text-gray-900">0</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bg-white rounded-lg shadow p-6">
+                <div class="flex items-center">
+                    <div class="p-2 bg-purple-100 rounded-lg">
+                        <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                    </div>
+                    <div class="ml-4">
+                        <p class="text-sm font-medium text-gray-600">Last Sync</p>
+                        <p id="last-sync" class="text-sm font-semibold text-gray-900">Never</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Sync Controls -->
+        <div class="bg-white rounded-lg shadow mb-8">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">Sync Controls</h2>
+            </div>
+            <div class="p-6">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <!-- Quick Sync Options -->
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-900 mb-3">Quick Sync Options</h3>
+                        <div class="space-y-2">
+                            <button onclick="runQuickSync('all')" class="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors">
+                                🔄 Full Sync (All Data)
+                            </button>
+                            <button onclick="runQuickSync('incremental')" class="w-full bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition-colors">
+                                ⚡ Incremental Sync (New Only)
+                            </button>
+                            <button onclick="runQuickSync('bookings')" class="w-full bg-purple-600 text-white px-4 py-2 rounded-md hover:bg-purple-700 transition-colors">
+                                📅 Bookings Only
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Custom Sync Configuration -->
+                    <div>
+                        <h3 class="text-sm font-medium text-gray-900 mb-3">Custom Sync</h3>
+                        <div class="space-y-3">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-1">Tables to Sync</label>
+                                <select id="sync-tables" multiple class="w-full border-gray-300 rounded-md shadow-sm">
+                                    <option value="bookings">Bookings</option>
+                                    <option value="contacts">Contacts</option>
+                                    <option value="orders">Orders</option>
+                                    <option value="products">Products</option>
+                                    <option value="loyalty">Loyalty</option>
+                                    <option value="services">Services</option>
+                                </select>
+                            </div>
+                            <div class="flex space-x-3">
+                                <div class="flex-1">
+                                    <label class="block text-sm font-medium text-gray-700 mb-1">Batch Size</label>
+                                    <input id="batch-size" type="number" value="100" min="10" max="500" class="w-full border-gray-300 rounded-md shadow-sm">
+                                </div>
+                                <div class="flex items-center mt-6">
+                                    <input id="skip-existing" type="checkbox" checked class="rounded border-gray-300">
+                                    <label for="skip-existing" class="ml-2 text-sm text-gray-700">Skip existing</label>
+                                </div>
+                            </div>
+                            <button onclick="runCustomSync()" class="w-full bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition-colors">
+                                🎯 Run Custom Sync
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Sync Status Tables -->
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+            <!-- Table Status -->
+            <div class="bg-white rounded-lg shadow">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Table Sync Status</h2>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Table</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Records</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Success Rate</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                            </tr>
+                        </thead>
+                        <tbody id="table-status" class="bg-white divide-y divide-gray-200">
+                            <!-- Will be populated by JavaScript -->
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Recent Operations -->
+            <div class="bg-white rounded-lg shadow">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Recent Sync Operations</h2>
+                </div>
+                <div class="p-6">
+                    <div id="recent-operations" class="space-y-3">
+                        <!-- Will be populated by JavaScript -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Data Quality Issues -->
+        <div class="bg-white rounded-lg shadow mb-8" id="quality-issues" style="display: none;">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">Data Quality Issues</h2>
+            </div>
+            <div class="p-6">
+                <div id="quality-issues-content">
+                    <!-- Will be populated by JavaScript -->
+                </div>
+            </div>
+        </div>
+
+        <!-- Progress Modal -->
+        <div id="progress-modal" class="fixed inset-0 bg-gray-600 bg-opacity-50 hidden items-center justify-center z-50">
+            <div class="bg-white rounded-lg shadow-xl p-6 max-w-md w-full mx-4">
+                <div class="text-center">
+                    <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+                    <h3 class="text-lg font-semibold text-gray-900 mb-2">Syncing Data...</h3>
+                    <p id="progress-message" class="text-gray-600">Initializing sync process...</p>
+                    <div class="mt-4 bg-gray-200 rounded-full h-2">
+                        <div id="progress-bar" class="bg-blue-600 h-2 rounded-full transition-all duration-300" style="width: 0%"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let syncStatus = null
+        let isLoading = false
+
+        // Initialize dashboard
+        document.addEventListener('DOMContentLoaded', function() {
+            loadSyncStatus()
+            // Refresh every 30 seconds
+            setInterval(loadSyncStatus, 30000)
+        })
+
+        async function loadSyncStatus() {
+            if (isLoading) return
+            isLoading = true
+
+            try {
+                const response = await fetch('/api/sync-status')
+                const data = await response.json()
+                
+                if (data.success) {
+                    syncStatus = data
+                    updateDashboard(data)
+                }
+            } catch (error) {
+                console.error('Failed to load sync status:', error)
+                showError('Failed to load sync status')
+            } finally {
+                isLoading = false
+            }
+        }
+
+        function updateDashboard(data) {
+            // Update overview cards
+            document.getElementById('sync-health').textContent = 
+                data.sync_health.overall_status.toUpperCase()
+            
+            const totalSynced = Object.values(data.sync_health.tables)
+                .reduce((sum, table) => sum + (table.synced || 0), 0)
+            document.getElementById('records-synced').textContent = totalSynced.toLocaleString()
+            
+            // Update last sync time
+            const lastSync = Math.max(...Object.values(data.sync_health.tables)
+                .map(table => table.last_sync ? new Date(table.last_sync).getTime() : 0))
+            
+            if (lastSync > 0) {
+                document.getElementById('last-sync').textContent = 
+                    new Date(lastSync).toLocaleString()
+            }
+
+            // Update table status
+            updateTableStatus(data.sync_health.tables)
+            
+            // Update recent operations
+            updateRecentOperations(data.sync_health.recent_operations)
+        }
+
+        function updateTableStatus(tables) {
+            const tbody = document.getElementById('table-status')
+            tbody.innerHTML = ''
+
+            Object.entries(tables).forEach(([tableName, stats]) => {
+                const row = document.createElement('tr')
+                row.innerHTML = `
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                        ${tableName.charAt(0).toUpperCase() + tableName.slice(1)}
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        ${stats.total_records || 0}
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        ${stats.success_rate || '0'}%
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap">
+                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusClass(stats.status)}">
+                            ${stats.status || 'unknown'}
+                        </span>
+                    </td>
+                `
+                tbody.appendChild(row)
+            })
+        }
+
+        function updateRecentOperations(operations) {
+            const container = document.getElementById('recent-operations')
+            container.innerHTML = ''
+
+            if (!operations || operations.length === 0) {
+                container.innerHTML = '<p class="text-gray-500 text-sm">No recent sync operations</p>'
+                return
+            }
+
+            operations.slice(0, 5).forEach(op => {
+                const div = document.createElement('div')
+                div.className = 'flex items-center justify-between p-3 bg-gray-50 rounded-md'
+                
+                const status = op.webhook_status === 'success' ? '✅' : '❌'
+                const time = new Date(op.logged_at).toLocaleString()
+                
+                div.innerHTML = `
+                    <div>
+                        <p class="text-sm font-medium text-gray-900">${op.event_type}</p>
+                        <p class="text-xs text-gray-500">${time}</p>
+                    </div>
+                    <span class="text-lg">${status}</span>
+                `
+                container.appendChild(div)
+            })
+        }
+
+        function getStatusClass(status) {
+            switch (status) {
+                case 'fully_synced': return 'bg-green-100 text-green-800'
+                case 'partial_success': return 'bg-yellow-100 text-yellow-800'
+                case 'mostly_failed': return 'bg-red-100 text-red-800'
+                case 'in_progress': return 'bg-blue-100 text-blue-800'
+                default: return 'bg-gray-100 text-gray-800'
+            }
+        }
+
+        // Sync control functions
+        async function runQuickSync(type) {
+            const configs = {
+                'all': {
+                    tables: ['all'],
+                    batchSize: 100,
+                    skipExisting: false
+                },
+                'incremental': {
+                    tables: ['bookings', 'contacts', 'orders'],
+                    batchSize: 100,
+                    skipExisting: true
+                },
+                'bookings': {
+                    tables: ['bookings'],
+                    batchSize: 100,
+                    skipExisting: true
+                }
+            }
+
+            await runSync(configs[type] || configs.all)
+        }
+
+        async function runCustomSync() {
+            const tables = Array.from(document.getElementById('sync-tables').selectedOptions)
+                .map(option => option.value)
+            
+            if (tables.length === 0) {
+                showError('Please select at least one table to sync')
+                return
+            }
+
+            const config = {
+                tables: tables,
+                batchSize: parseInt(document.getElementById('batch-size').value) || 100,
+                skipExisting: document.getElementById('skip-existing').checked
+            }
+
+            await runSync(config)
+        }
+
+        async function runSync(config) {
+            showProgress('Starting sync process...')
+            
+            try {
+                console.log('🚀 Starting sync with config:', config)
+                
+                const response = await fetch('/api/sync-all-wix-data', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(config)
+                })
+
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+                }
+
+                const result = await response.json()
+                
+                hideProgress()
+                
+                if (result.success) {
+                    showSuccess('Sync completed successfully!')
+                    
+                    // Display results
+                    displaySyncResults(result.results)
+                    
+                    // Refresh status
+                    await loadSyncStatus()
+                } else {
+                    throw new Error(result.error || 'Sync failed')
+                }
+                
+            } catch (error) {
+                hideProgress()
+                showError(`Sync failed: ${error.message}`)
+                console.error('Sync error:', error)
+            }
+        }
+
+        function displaySyncResults(results) {
+            let message = 'Sync Results:\n\n'
+            
+            Object.entries(results).forEach(([table, stats]) => {
+                message += `${table.toUpperCase()}:\n`
+                message += `  ✅ Synced: ${stats.synced || 0}\n`
+                message += `  ❌ Errors: ${stats.errors || 0}\n\n`
+            })
+            
+            alert(message)
+        }
+
+        function showProgress(message) {
+            document.getElementById('progress-message').textContent = message
+            document.getElementById('progress-modal').style.display = 'flex'
+        }
+
+        function updateProgress(message, percentage) {
+            document.getElementById('progress-message').textContent = message
+            document.getElementById('progress-bar').style.width = `${percentage}%`
+        }
+
+        function hideProgress() {
+            document.getElementById('progress-modal').style.display = 'none'
+        }
+
+        function showSuccess(message) {
+            const alert = createAlert(message, 'success')
+            document.body.appendChild(alert)
+            setTimeout(() => alert.remove(), 5000)
+        }
+
+        function showError(message) {
+            const alert = createAlert(message, 'error')
+            document.body.appendChild(alert)
+            setTimeout(() => alert.remove(), 8000)
+        }
+
+        function createAlert(message, type) {
+            const div = document.createElement('div')
+            div.className = `fixed top-4 right-4 p-4 rounded-md shadow-lg z-50 max-w-sm ${type === 'success' ? 'bg-green-100 border border-green-400 text-green-700' : 'bg-red-100 border border-red-400 text-red-700'}`
+            
+            div.innerHTML = `
+                <div class="flex">
+                    <div class="flex-shrink-0">
+                        ${type === 'success' ? '✅' : '❌'}
+                    </div>
+                    <div class="ml-3">
+                        <p class="text-sm font-medium">${message}</p>
+                    </div>
+                    <div class="ml-auto pl-3">
+                        <button onclick="this.parentElement.parentElement.remove()" class="text-gray-400 hover:text-gray-600">
+                            <span class="sr-only">Dismiss</span>
+                            ✕
+                        </button>
+                    </div>
+                </div>
+            `
+            
+            return div
+        }
+
+        // Additional utility functions
+        async function validateSync() {
+            showProgress('Running validation...')
+            
+            try {
+                const response = await fetch('/api/sync-status', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'validate' })
+                })
+
+                const result = await response.json()
+                hideProgress()
+                
+                if (result.success) {
+                    showValidationResults(result)
+                } else {
+                    showError('Validation failed')
+                }
+            } catch (error) {
+                hideProgress()
+                showError(`Validation failed: ${error.message}`)
+            }
+        }
+
+        function showValidationResults(results) {
+            // Show validation score
+            const score = results.validation_score || 0
+            let message = `Validation Score: ${score}/100\n\n`
+            
+            // Show recommendations
+            if (results.recommendations && results.recommendations.length > 0) {
+                message += 'Recommendations:\n'
+                results.recommendations.forEach(rec => {
+                    message += `• ${rec.action}: ${rec.description}\n`
+                })
+            } else {
+                message += 'No issues found! Your sync is in excellent condition.'
+            }
+            
+            alert(message)
+        }
+
+        async function resetSyncStatus(table = 'all') {
+            if (!confirm(`Are you sure you want to reset sync status for ${table}? This will mark all records as pending sync.`)) {
+                return
+            }
+            
+            showProgress('Resetting sync status...')
+            
+            try {
+                const response = await fetch(`/api/sync-status?table=${table}&confirm=true`, {
+                    method: 'DELETE'
+                })
+
+                const result = await response.json()
+                hideProgress()
+                
+                if (result.success) {
+                    showSuccess('Sync status reset successfully')
+                    await loadSyncStatus()
+                } else {
+                    showError('Failed to reset sync status')
+                }
+            } catch (error) {
+                hideProgress()
+                showError(`Reset failed: ${error.message}`)
+            }
+        }
+
+        // Auto-refresh indicator
+        let refreshTimer = null
+        function startAutoRefresh() {
+            if (refreshTimer) clearInterval(refreshTimer)
+            refreshTimer = setInterval(loadSyncStatus, 30000)
+        }
+
+        function stopAutoRefresh() {
+            if (refreshTimer) {
+                clearInterval(refreshTimer)
+                refreshTimer = null
+            }
+        }
+
+        // Initialize auto-refresh
+        startAutoRefresh()
+    </script>
+
+    <!-- Additional Control Buttons -->
+    <div class="fixed bottom-6 right-6 space-y-2">
+        <button onclick="validateSync()" 
+                class="bg-yellow-600 hover:bg-yellow-700 text-white p-3 rounded-full shadow-lg transition-colors"
+                title="Validate Sync">
+            🔍
+        </button>
+        <button onclick="resetSyncStatus()" 
+                class="bg-red-600 hover:bg-red-700 text-white p-3 rounded-full shadow-lg transition-colors"
+                title="Reset Sync Status">
+            🔄
+        </button>
+        <button onclick="loadSyncStatus()" 
+                class="bg-green-600 hover:bg-green-700 text-white p-3 rounded-full shadow-lg transition-colors"
+                title="Refresh Status">
+            ↻
+        </button>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sync status API with control and validation endpoints
- include static dashboard for monitoring sync health

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aa86bcaf2c832aabd684862947504f