### PR TITLE
feat: make appointment cards clickable

### DIFF
--- a/components/AppointmentCard.js
+++ b/components/AppointmentCard.js
@@ -1,6 +1,8 @@
 import styles from './AppointmentCard.module.css'
+import { useRouter } from 'next/router'
 
 export default function AppointmentCard({ appointment, onComplete, onCancel, onReschedule, onMarkPaid, onEditNotes }) {
+  const router = useRouter()
   const {
     id,
     customer_name,
@@ -13,8 +15,12 @@ export default function AppointmentCard({ appointment, onComplete, onCancel, onR
     notes,
   } = appointment
 
+  const handleCardClick = () => {
+    router.push(`/product-usage/${id}`)
+  }
+
   return (
-    <div className={styles.card}>
+    <div className={styles.card} onClick={handleCardClick}>
       <div className={styles.header}>
         <div>
           <strong>{customer_name || 'Customer'}</strong>
@@ -32,17 +38,17 @@ export default function AppointmentCard({ appointment, onComplete, onCancel, onR
       </div>
       {notes && <div className={styles.notes}>Notes: {notes.substring(0, 80)}</div>}
       <div className={styles.actions}>
-        <button onClick={() => onComplete(appointment)}>Complete</button>
-        <button onClick={() => onCancel(appointment)}>Cancel</button>
-        <button onClick={() => onReschedule(appointment)}>Reschedule</button>
+        <button onClick={(e) => { e.stopPropagation(); onComplete(appointment) }}>Complete</button>
+        <button onClick={(e) => { e.stopPropagation(); onCancel(appointment) }}>Cancel</button>
+        <button onClick={(e) => { e.stopPropagation(); onReschedule(appointment) }}>Reschedule</button>
         {payment_status !== 'paid' && (
-          <button onClick={() => onMarkPaid(appointment)}>Mark Paid</button>
+          <button onClick={(e) => { e.stopPropagation(); onMarkPaid(appointment) }}>Mark Paid</button>
         )}
-        <button onClick={() => onEditNotes(appointment)}>Notes</button>
-        <button onClick={() => window.open(`/product-usage/${id}`, '_blank')}>Usage</button>
-        <button onClick={() => window.open(`/booking-images/${id}`, '_blank')}>Images</button>
-        <button onClick={() => window.open(`/booking-details/${id}`, '_blank')}>Details</button>
-        <button onClick={() => window.open(`/collect-payment/${id}`, '_blank')}>Collect</button>
+        <button onClick={(e) => { e.stopPropagation(); onEditNotes(appointment) }}>Notes</button>
+        <button onClick={(e) => { e.stopPropagation(); window.open(`/product-usage/${id}`, '_blank') }}>Usage</button>
+        <button onClick={(e) => { e.stopPropagation(); window.open(`/booking-images/${id}`, '_blank') }}>Images</button>
+        <button onClick={(e) => { e.stopPropagation(); window.open(`/booking-details/${id}`, '_blank') }}>Details</button>
+        <button onClick={(e) => { e.stopPropagation(); window.open(`/collect-payment/${id}`, '_blank') }}>Collect</button>
       </div>
     </div>
   )

--- a/components/AppointmentCard.module.css
+++ b/components/AppointmentCard.module.css
@@ -9,6 +9,7 @@
   gap: 8px;
   text-align: center;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
 }
 .card:hover {
   transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- Allow appointment cards to open the product usage form when clicked
- Prevent action buttons from triggering navigation and keep individual actions
- Add pointer cursor styling to emphasize card interactivity

## Testing
- `npm test` *(fails: dynamic import callback without --experimental-vm-modules, Supabase client not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68ab217f04a0832a8aff3b4f9983361f