### PR TITLE
feat: add resilient wix api client and webhook retry

### DIFF
--- a/api/retry-failed-webhooks.js
+++ b/api/retry-failed-webhooks.js
@@ -1,0 +1,71 @@
+// api/retry-failed-webhooks.js
+// Endpoint to retry processing of failed webhooks
+
+import { createClient } from '@supabase/supabase-js';
+import { WebhookProcessor } from '../lib/webhook-processor';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const { days = 7, limit = 100 } = req.body || {};
+
+  try {
+    const { data: failedWebhooks } = await supabase
+      .from('webhook_logs')
+      .select('*')
+      .eq('webhook_status', 'failed')
+      .gte('logged_at', new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString())
+      .order('logged_at', { ascending: false })
+      .limit(limit);
+
+    const processor = new WebhookProcessor(supabase);
+    const results = {
+      total: failedWebhooks.length,
+      retried: 0,
+      succeeded: 0,
+      still_failing: 0
+    };
+
+    for (const webhook of failedWebhooks) {
+      try {
+        console.log(`🔄 Retrying: ${webhook.event_type} (ID: ${webhook.id})`);
+        await processor.processWebhook(webhook.event_type, webhook.data.event_data);
+        await supabase
+          .from('webhook_logs')
+          .update({
+            webhook_status: 'retried_success',
+            data: {
+              ...webhook.data,
+              retried_at: new Date().toISOString()
+            }
+          })
+          .eq('id', webhook.id);
+        results.succeeded++;
+      } catch (error) {
+        console.error(`❌ Retry failed for webhook ${webhook.id}:`, error);
+        results.still_failing++;
+      }
+      results.retried++;
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+
+    res.status(200).json({
+      success: true,
+      message: 'Webhook retry completed',
+      results,
+      timestamp: new Date().toISOString()
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: error.message
+    });
+  }
+}

--- a/lib/webhook-processor.js
+++ b/lib/webhook-processor.js
@@ -1,0 +1,247 @@
+// lib/webhook-processor.js
+// Handles processing Wix webhooks with dependency checking and retries
+
+import { wixAPI } from './wix-api-client';
+import { WixDataTransformers } from './wix-transformers';
+
+export class WebhookProcessor {
+  constructor(supabase) {
+    this.supabase = supabase;
+    this.processingQueue = [];
+  }
+
+  async processWebhook(eventType, eventData) {
+    console.log(`📥 Processing webhook: ${eventType}`);
+    try {
+      const task = {
+        id: Date.now() + Math.random(),
+        eventType,
+        eventData,
+        dependencies: this.getDependencies(eventType),
+        attempts: 0,
+        maxAttempts: 3,
+        createdAt: new Date()
+      };
+      await this.executeWithDependencies(task);
+      return { success: true, eventType };
+    } catch (error) {
+      console.error(`❌ Webhook processing failed for ${eventType}:`, error);
+      await this.logFailedWebhook(eventType, eventData, error);
+      throw error;
+    }
+  }
+
+  getDependencies(eventType) {
+    const dependencies = {
+      'booking_created': ['contact_exists'],
+      'booking_updated': ['contact_exists', 'booking_exists'],
+      'order_created': ['contact_exists'],
+      'order_updated': ['contact_exists', 'order_exists']
+    };
+    return dependencies[eventType] || [];
+  }
+
+  async executeWithDependencies(task) {
+    const { eventType, eventData, dependencies } = task;
+    for (const dependency of dependencies) {
+      const satisfied = await this.checkDependency(dependency, eventData);
+      if (!satisfied) {
+        await this.resolveDependency(dependency, eventData);
+      }
+    }
+    switch (eventType) {
+      case 'booking_created':
+      case 'booking_updated':
+        return await this.processBooking(eventData);
+      case 'contact_created':
+      case 'contact_updated':
+        return await this.processContact(eventData);
+      case 'order_created':
+      case 'order_updated':
+        return await this.processOrder(eventData);
+      default:
+        console.log(`⚠️ Unknown event type: ${eventType}`);
+        return await this.logUnknownEvent(eventType, eventData);
+    }
+  }
+
+  async checkDependency(dependency, eventData) {
+    switch (dependency) {
+      case 'contact_exists': {
+        const contactEmail = WixDataTransformers.extractEmail(eventData);
+        if (!contactEmail) return true;
+        const { data: contact } = await this.supabase
+          .from('contacts')
+          .select('id')
+          .eq('email', contactEmail)
+          .maybeSingle();
+        return !!contact;
+      }
+      case 'booking_exists': {
+        const wixBookingId = eventData.id || eventData.bookingId;
+        if (!wixBookingId) return true;
+        const { data: booking } = await this.supabase
+          .from('bookings')
+          .select('id')
+          .eq('wix_booking_id', wixBookingId)
+          .maybeSingle();
+        return !!booking;
+      }
+      default:
+        return true;
+    }
+  }
+
+  async resolveDependency(dependency, eventData) {
+    console.log(`🔧 Resolving dependency: ${dependency}`);
+    switch (dependency) {
+      case 'contact_exists': {
+        const contactEmail = WixDataTransformers.extractEmail(eventData);
+        if (contactEmail) {
+          await this.fetchAndCreateContact(contactEmail);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  async fetchAndCreateContact(email) {
+    try {
+      const wixContacts = await wixAPI.makeRequest('/contacts/v4/contacts/query', 'POST', {
+        query: {
+          filter: { email: { $eq: email } },
+          paging: { limit: 1 }
+        }
+      });
+      if (wixContacts.contacts && wixContacts.contacts.length > 0) {
+        const wixContact = wixContacts.contacts[0];
+        const contactRecord = WixDataTransformers.transformContact(wixContact);
+        await this.supabase
+          .from('contacts')
+          .upsert(contactRecord, { onConflict: 'email' });
+        console.log(`✅ Created missing contact: ${email}`);
+      }
+    } catch (error) {
+      console.error(`❌ Failed to fetch contact ${email}:`, error);
+    }
+  }
+
+  async processBooking(bookingData) {
+    const bookingRecord = WixDataTransformers.transformBooking(bookingData);
+    if (bookingRecord.customer_email) {
+      const { data: customer } = await this.supabase
+        .from('contacts')
+        .select('id')
+        .eq('email', bookingRecord.customer_email)
+        .maybeSingle();
+      if (customer) {
+        bookingRecord.customer_id = customer.id;
+      }
+    }
+    if (bookingRecord.service_name) {
+      const { data: service } = await this.supabase
+        .from('salon_services')
+        .select('id')
+        .or(`name.ilike.%${bookingRecord.service_name}%,wix_service_id.eq.${bookingRecord.wix_service_id}`)
+        .maybeSingle();
+      if (service) {
+        bookingRecord.service_id = service.id;
+        const { data: serviceDetails } = await this.supabase
+          .from('salon_services')
+          .select('price')
+          .eq('id', service.id)
+          .single();
+        if (serviceDetails) {
+          bookingRecord.total_price = serviceDetails.price;
+        }
+      }
+    }
+    if (bookingRecord.staff_member) {
+      const { data: staff } = await this.supabase
+        .from('staff')
+        .select('id')
+        .ilike("first_name || ' ' || last_name", `%${bookingRecord.staff_member}%`)
+        .maybeSingle();
+      if (staff) {
+        bookingRecord.staff_id = staff.id;
+      }
+    }
+    const { data, error } = await this.supabase
+      .from('bookings')
+      .upsert(bookingRecord, { onConflict: 'wix_booking_id' })
+      .select()
+      .single();
+    if (error) throw error;
+    console.log(`✅ Booking processed: ${bookingRecord.wix_booking_id}`);
+    return data;
+  }
+
+  async processContact(contactData) {
+    const contactRecord = WixDataTransformers.transformContact(contactData);
+    const { data, error } = await this.supabase
+      .from('contacts')
+      .upsert(contactRecord, { onConflict: 'wix_contact_id' })
+      .select()
+      .single();
+    if (error) throw error;
+    console.log(`✅ Contact processed: ${contactRecord.email}`);
+    return data;
+  }
+
+  async processOrder(orderData) {
+    const orderRecord = WixDataTransformers.transformOrder(orderData);
+    if (orderRecord.customer_email) {
+      const { data: customer } = await this.supabase
+        .from('contacts')
+        .select('id')
+        .eq('email', orderRecord.customer_email)
+        .maybeSingle();
+      if (customer) {
+        orderRecord.customer_id = customer.id;
+      }
+    }
+    const { data, error } = await this.supabase
+      .from('orders')
+      .upsert(orderRecord, { onConflict: 'wix_order_id' })
+      .select()
+      .single();
+    if (error) throw error;
+    console.log(`✅ Order processed: ${orderRecord.wix_order_id}`);
+    return data;
+  }
+
+  async logFailedWebhook(eventType, eventData, error) {
+    await this.supabase
+      .from('webhook_logs')
+      .insert({
+        event_type: eventType,
+        webhook_status: 'failed',
+        error_message: error.message,
+        data: {
+          error: error.message,
+          stack: error.stack,
+          event_data: eventData,
+          timestamp: new Date().toISOString()
+        }
+      });
+  }
+
+  async logUnknownEvent(eventType, eventData) {
+    await this.supabase
+      .from('webhook_logs')
+      .insert({
+        event_type: 'unknown_webhook_event',
+        webhook_status: 'logged',
+        data: {
+          event_type: eventType,
+          event_data: eventData,
+          timestamp: new Date().toISOString()
+        }
+      });
+    return { type: 'unknown', eventType, logged: true };
+  }
+}
+
+export default WebhookProcessor;

--- a/lib/wix-api-client.js
+++ b/lib/wix-api-client.js
@@ -1,0 +1,76 @@
+// lib/wix-api-client.js
+// Provides a rate limited Wix API wrapper with retry logic
+
+class WixAPIClient {
+  constructor() {
+    this.baseURL = 'https://www.wixapis.com';
+    this.token = process.env.WIX_API_TOKEN;
+    this.siteId = process.env.WIX_SITE_ID;
+    this.requestCount = 0;
+    this.lastRequestTime = 0;
+  }
+
+  async makeRequest(endpoint, method = 'GET', data = null, retries = 3) {
+    await this.rateLimitDelay();
+
+    const url = `${this.baseURL}${endpoint}`;
+    const options = {
+      method,
+      headers: {
+        'Authorization': this.token,
+        'wix-site-id': this.siteId,
+        'Content-Type': 'application/json'
+      }
+    };
+
+    if (data && method !== 'GET') {
+      options.body = JSON.stringify(data);
+    }
+
+    for (let attempt = 1; attempt <= retries; attempt++) {
+      try {
+        console.log(`🔄 API Request (attempt ${attempt}): ${method} ${endpoint}`);
+        const response = await fetch(url, options);
+
+        if (response.status === 429) {
+          const retryAfter = response.headers.get('retry-after') || 5;
+          console.log(`⏱️ Rate limited, waiting ${retryAfter}s...`);
+          await this.delay(retryAfter * 1000);
+          continue;
+        }
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+        }
+
+        const result = await response.json();
+        console.log(`✅ API Success: ${endpoint}`);
+        return result;
+      } catch (error) {
+        console.error(`❌ API Error (attempt ${attempt}):`, error.message);
+        if (attempt === retries) {
+          throw error;
+        }
+        await this.delay(Math.pow(2, attempt) * 1000);
+      }
+    }
+  }
+
+  async rateLimitDelay() {
+    const now = Date.now();
+    const timeSinceLastRequest = now - this.lastRequestTime;
+    if (timeSinceLastRequest < 200) {
+      await this.delay(200 - timeSinceLastRequest);
+    }
+    this.lastRequestTime = Date.now();
+    this.requestCount++;
+  }
+
+  delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}
+
+export const wixAPI = new WixAPIClient();
+
+export default WixAPIClient;

--- a/lib/wix-transformers.js
+++ b/lib/wix-transformers.js
@@ -1,0 +1,168 @@
+// lib/wix-transformers.js
+// Provides data transformation helpers for Wix webhook payloads
+
+export class WixDataTransformers {
+  static transformBooking(wixBooking) {
+    console.log('🔄 Transforming booking:', wixBooking.id);
+
+    const contactDetails = wixBooking.contactDetails || wixBooking.bookedEntity?.contactDetails;
+    const bookedEntity = wixBooking.bookedEntity || wixBooking;
+    const slot = bookedEntity?.slot || wixBooking.slot || wixBooking;
+
+    const appointmentDate = this.parseWixDate(
+      wixBooking.startDate ||
+      slot?.startDate ||
+      wixBooking.bookedEntity?.startDate
+    );
+
+    const endTime = this.parseWixDate(
+      wixBooking.endDate ||
+      slot?.endDate ||
+      wixBooking.bookedEntity?.endDate
+    );
+
+    let durationMinutes = 60;
+    if (appointmentDate && endTime) {
+      durationMinutes = Math.round((new Date(endTime) - new Date(appointmentDate)) / (1000 * 60));
+    }
+
+    const customerEmail = this.extractEmail(contactDetails) ||
+      this.extractEmail(wixBooking) ||
+      wixBooking.contactInfo?.email;
+
+    const customerName = this.extractName(contactDetails) ||
+      this.extractName(wixBooking) ||
+      'Unknown Customer';
+
+    const transformed = {
+      wix_booking_id: wixBooking.id,
+      customer_email: customerEmail,
+      customer_name: customerName,
+      customer_phone: this.extractPhone(contactDetails) || this.extractPhone(wixBooking),
+      wix_contact_id: contactDetails?.contactId || contactDetails?.id || wixBooking.contactId,
+      service_name: bookedEntity?.title || bookedEntity?.name || bookedEntity?.serviceName || 'Unknown Service',
+      service_duration: durationMinutes,
+      wix_service_id: bookedEntity?.serviceId || bookedEntity?.id,
+      appointment_date: appointmentDate,
+      end_time: endTime,
+      staff_member: slot?.resource?.name || wixBooking.resource?.name || bookedEntity?.staffMember,
+      wix_staff_resource_id: slot?.resource?.id || wixBooking.resource?.id,
+      location: slot?.location?.name || wixBooking.location?.name || 'Keeping It Cute Salon & Spa',
+      number_of_participants: parseInt(wixBooking.numberOfParticipants || wixBooking.totalParticipants || 1),
+      payment_status: (wixBooking.paymentStatus || 'UNDEFINED').toLowerCase(),
+      status: (wixBooking.status || 'CONFIRMED').toLowerCase(),
+      business_id: wixBooking.businessId || process.env.WIX_SITE_ID,
+      revision: parseInt(wixBooking.revision) || 1,
+      notes: wixBooking.additionalInformation || wixBooking.notes,
+      sync_status: 'synced',
+      last_synced_at: new Date().toISOString(),
+      raw_data: wixBooking
+    };
+
+    console.log('✅ Booking transformed:', {
+      id: transformed.wix_booking_id,
+      customer: transformed.customer_name,
+      service: transformed.service_name,
+      date: transformed.appointment_date
+    });
+
+    return transformed;
+  }
+
+  static transformContact(wixContact) {
+    console.log('🔄 Transforming contact:', wixContact.id);
+
+    const info = wixContact.info || wixContact;
+    const name = info.name || {};
+    const emails = info.emails || [];
+    const phones = info.phones || [];
+    const addresses = info.addresses || [];
+
+    return {
+      wix_contact_id: wixContact.id,
+      first_name: name.first || info.firstName || '',
+      last_name: name.last || info.lastName || '',
+      email: emails[0]?.email || info.email || wixContact.email,
+      phone: phones[0]?.phone || info.phone || wixContact.phone,
+      address_line1: addresses[0]?.street || '',
+      city: addresses[0]?.city || '',
+      state: addresses[0]?.subdivision || '',
+      zip_code: addresses[0]?.zipCode || '',
+      country: addresses[0]?.country || '',
+      created_at: this.parseWixDate(wixContact.createdDate) || new Date().toISOString(),
+      updated_at: this.parseWixDate(wixContact.updatedDate) || new Date().toISOString(),
+      sync_status: 'synced',
+      last_synced_at: new Date().toISOString(),
+      payload: wixContact
+    };
+  }
+
+  static transformOrder(wixOrder) {
+    console.log('🔄 Transforming order:', wixOrder.id);
+
+    const billingInfo = wixOrder.billingInfo || {};
+    const buyerInfo = wixOrder.buyerInfo || {};
+    const totals = wixOrder.totals || {};
+
+    return {
+      wix_order_id: wixOrder.id,
+      customer_email: buyerInfo.email || billingInfo.email || wixOrder.customerEmail,
+      customer_name: `${buyerInfo.firstName || billingInfo.firstName || ''} ${buyerInfo.lastName || billingInfo.lastName || ''}`.trim(),
+      wix_contact_id: buyerInfo.contactId || wixOrder.contactId,
+      order_number: wixOrder.number || wixOrder.orderNumber,
+      status: (wixOrder.status || 'PENDING').toLowerCase(),
+      subtotal: parseFloat(totals.subtotal || wixOrder.subtotal || 0),
+      tax_amount: parseFloat(totals.tax || wixOrder.tax || 0),
+      total_amount: parseFloat(totals.total || wixOrder.total || 0),
+      currency: wixOrder.currency || 'USD',
+      created_at: this.parseWixDate(wixOrder.dateCreated) || new Date().toISOString(),
+      updated_at: this.parseWixDate(wixOrder.dateUpdated) || new Date().toISOString(),
+      sync_status: 'synced',
+      last_synced_at: new Date().toISOString(),
+      payload: wixOrder
+    };
+  }
+
+  static parseWixDate(dateString) {
+    if (!dateString) return null;
+    try {
+      const date = new Date(dateString);
+      return date.toISOString();
+    } catch (error) {
+      console.error('❌ Date parsing error:', error);
+      return null;
+    }
+  }
+
+  static extractEmail(data) {
+    if (!data) return null;
+    return data.email ||
+      data.emails?.[0]?.email ||
+      data.contactDetails?.email ||
+      data.buyerInfo?.email ||
+      data.billingInfo?.email ||
+      null;
+  }
+
+  static extractName(data) {
+    if (!data) return null;
+    if (data.firstName || data.lastName) {
+      return `${data.firstName || ''} ${data.lastName || ''}`.trim();
+    }
+    if (data.name?.first || data.name?.last) {
+      return `${data.name.first || ''} ${data.name.last || ''}`.trim();
+    }
+    if (data.contactDetails?.firstName || data.contactDetails?.lastName) {
+      return `${data.contactDetails.firstName || ''} ${data.contactDetails.lastName || ''}`.trim();
+    }
+    return data.name || data.displayName || null;
+  }
+
+  static extractPhone(data) {
+    if (!data) return null;
+    return data.phone ||
+      data.phones?.[0]?.phone ||
+      data.contactDetails?.phone ||
+      null;
+  }
+}


### PR DESCRIPTION
## Summary
- add rate-limited Wix API wrapper with retries
- implement data transformers and webhook processor for dependency-aware sync
- add endpoint to retry failed webhooks

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b62f96ec38832a9f38d80580d740b2