### PR TITLE
refactor: apply standardized API error handling

### DIFF
--- a/api/appointments.js
+++ b/api/appointments.js
@@ -1,73 +1,68 @@
 // api/appointments.js - Get appointments with filtering
 import { createSupabaseClient } from '../utils/supabaseClient'
+import { withErrorHandler, APIError } from '../utils/errorHandler'
 
 const supabase = createSupabaseClient()
 
-export default async function handler(req, res) {
+const handler = async (req, res) => {
   if (req.method !== 'GET') {
-    return res.status(405).json({ error: 'Method Not Allowed' })
+    throw new APIError('Method not allowed', 405, 'METHOD_NOT_ALLOWED')
   }
 
-  try {
-    const {
-      date,
-      status,
-      payment_status,
-      staff_id,
-      customer_id,
-      limit = '50'
-    } = req.query
+  const {
+    date,
+    status,
+    payment_status,
+    staff_id,
+    customer_id,
+    limit = '50'
+  } = req.query
 
-    let query = supabase
-      .from('salon_appointments')
-      .select(`
+  let query = supabase
+    .from('salon_appointments')
+    .select(`
         *,
         customers(*),
         salon_services(*),
         staff(*)
       `)
-      .order('appointment_date', { ascending: false })
-      .limit(parseInt(limit))
+    .order('appointment_date', { ascending: false })
+    .limit(parseInt(limit))
 
-    if (date) {
-      query = query
-        .gte('appointment_date', `${date}T00:00:00`)
-        .lt('appointment_date', `${date}T23:59:59`)
-    }
-
-    if (status) {
-      query = query.eq('status', status)
-    }
-
-    if (payment_status) {
-      query = query.eq('payment_status', payment_status)
-    }
-
-    if (staff_id) {
-      query = query.eq('staff_id', staff_id)
-    }
-
-    if (customer_id) {
-      query = query.eq('customer_id', customer_id)
-    }
-
-    const { data: appointments, error } = await query
-
-    if (error) {
-      throw error
-    }
-
-    res.status(200).json({
-      success: true,
-      appointments,
-      count: appointments.length,
-      timestamp: new Date().toISOString()
-    })
-  } catch (err) {
-    console.error('❌ Appointments API Error:', err)
-    res.status(500).json({
-      error: 'Failed to fetch appointments',
-      details: err.message
-    })
+  if (date) {
+    query = query
+      .gte('appointment_date', `${date}T00:00:00`)
+      .lt('appointment_date', `${date}T23:59:59`)
   }
+
+  if (status) {
+    query = query.eq('status', status)
+  }
+
+  if (payment_status) {
+    query = query.eq('payment_status', payment_status)
+  }
+
+  if (staff_id) {
+    query = query.eq('staff_id', staff_id)
+  }
+
+  if (customer_id) {
+    query = query.eq('customer_id', customer_id)
+  }
+
+  const { data: appointments, error } = await query
+
+  if (error) {
+    throw new APIError('Failed to fetch appointments', 500, 'DATABASE_ERROR')
+  }
+
+  res.status(200).json({
+    success: true,
+    appointments,
+    count: appointments.length,
+    timestamp: new Date().toISOString()
+  })
 }
+
+export default withErrorHandler(handler)

--- a/pages/api/auth/confirm.js
+++ b/pages/api/auth/confirm.js
@@ -1,29 +1,34 @@
 import createClient from '../../../utils/supabase/api'
+import { withErrorHandler, APIError } from '../../../utils/errorHandler'
 
 function stringOrFirstString(item) {
   return Array.isArray(item) ? item[0] : item
 }
 
-export default async function handler(req, res) {
+const handler = async (req, res) => {
   if (req.method !== 'GET') {
-    res.status(405).setHeader('Allow', 'GET').end()
-    return
+    throw new APIError('Method not allowed', 405, 'METHOD_NOT_ALLOWED')
   }
 
-    const token_hash = stringOrFirstString(req.query.token_hash)
-    const type = stringOrFirstString(req.query.type)
-    let next = '/error'
+  const token_hash = stringOrFirstString(req.query.token_hash)
+  const type = stringOrFirstString(req.query.type)
 
-    if (token_hash && type) {
-      const supabase = createClient(req, res)
-      const { error } = await supabase.auth.verifyOtp({
-        token_hash,
-        type, // 'email', 'recovery', 'invite', 'email_change', etc.
-      })
-      if (!error) {
-        next = stringOrFirstString(req.query.next) || '/'
-      }
-    }
+  if (!token_hash || !type) {
+    throw new APIError('Missing token or type', 400, 'INVALID_REQUEST')
+  }
 
+  const supabase = createClient(req, res)
+  const { error } = await supabase.auth.verifyOtp({
+    token_hash,
+    type // 'email', 'recovery', 'invite', 'email_change', etc.
+  })
+
+  if (error) {
+    throw new APIError('Invalid or expired token', 400, 'INVALID_TOKEN')
+  }
+
+  const next = stringOrFirstString(req.query.next) || '/'
   res.redirect(next)
 }
+
+export default withErrorHandler(handler)

--- a/pages/api/exchange-code.js
+++ b/pages/api/exchange-code.js
@@ -1,25 +1,37 @@
-export default async function handler(req, res) {
+import { withErrorHandler, APIError } from '../../utils/errorHandler'
+
+const handler = async (req, res) => {
+  if (req.method !== 'POST') {
+    throw new APIError('Method not allowed', 405, 'METHOD_NOT_ALLOWED')
+  }
+
   const { code } = req.body
 
   const response = await fetch('https://www.wixapis.com/oauth/access', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify({
       grant_type: 'authorization_code',
       client_id: process.env.WIX_CLIENT_ID,
       client_secret: process.env.WIX_CLIENT_SECRET,
       code,
-      redirect_uri: process.env.NEXT_PUBLIC_WIX_REDIRECT_URI,
-    }),
+      redirect_uri: process.env.NEXT_PUBLIC_WIX_REDIRECT_URI
+    })
   })
+
+  if (!response.ok) {
+    throw new APIError('Failed to exchange code', response.status, 'WIX_OAUTH_ERROR')
+  }
 
   const data = await response.json()
 
-  if (data.access_token) {
-    res.status(200).json({ success: true, token: data })
-  } else {
-    res.status(400).json({ success: false, error: data })
+  if (!data.access_token) {
+    throw new APIError('Failed to exchange code', 400, 'WIX_OAUTH_ERROR')
   }
+
+  res.status(200).json({ success: true, token: data })
 }
+
+export default withErrorHandler(handler)

--- a/pages/api/sync/bookings.js
+++ b/pages/api/sync/bookings.js
@@ -1,15 +1,14 @@
-import { SyncService } from '../../../lib/sync-service';
+import { SyncService } from '../../../lib/sync-service'
+import { withErrorHandler, APIError } from '../../../utils/errorHandler'
 
-export default async function handler(req, res) {
+const handler = async (req, res) => {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    throw new APIError('Method not allowed', 405, 'METHOD_NOT_ALLOWED')
   }
 
-  try {
-    const syncService = new SyncService();
-    const result = await syncService.syncBookingsFromWix();
-    res.status(200).json(result);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
+  const syncService = new SyncService()
+  const result = await syncService.syncBookingsFromWix()
+  res.status(200).json(result)
 }
+
+export default withErrorHandler(handler)

--- a/pages/api/sync/clients.js
+++ b/pages/api/sync/clients.js
@@ -1,15 +1,14 @@
-import { SyncService } from '../../../lib/sync-service';
+import { SyncService } from '../../../lib/sync-service'
+import { withErrorHandler, APIError } from '../../../utils/errorHandler'
 
-export default async function handler(req, res) {
+const handler = async (req, res) => {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    throw new APIError('Method not allowed', 405, 'METHOD_NOT_ALLOWED')
   }
 
-  try {
-    const syncService = new SyncService();
-    const result = await syncService.syncClientsFromWix();
-    res.status(200).json(result);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
+  const syncService = new SyncService()
+  const result = await syncService.syncClientsFromWix()
+  res.status(200).json(result)
 }
+
+export default withErrorHandler(handler)

--- a/pages/api/webhooks/wix.js
+++ b/pages/api/webhooks/wix.js
@@ -1,30 +1,28 @@
-import { SyncService } from '../../../lib/sync-service';
+import { SyncService } from '../../../lib/sync-service'
+import { withErrorHandler, APIError } from '../../../utils/errorHandler'
 
-export default async function handler(req, res) {
+const handler = async (req, res) => {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+    throw new APIError('Method not allowed', 405, 'METHOD_NOT_ALLOWED')
   }
 
-  try {
-    const { eventType, data } = req.body;
-    const syncService = new SyncService();
+  const { eventType, data } = req.body
+  const syncService = new SyncService()
 
-    switch (eventType) {
-      case 'ContactCreated':
-      case 'ContactUpdated':
-        await syncService.handleContactWebhook(data);
-        break;
-      case 'BookingCreated':
-      case 'BookingUpdated':
-        await syncService.handleBookingWebhook(data);
-        break;
-      default:
-        console.log('Unhandled webhook event:', eventType);
-    }
-
-    res.status(200).json({ success: true });
-  } catch (error) {
-    console.error('Webhook error:', error);
-    res.status(500).json({ error: error.message });
+  switch (eventType) {
+    case 'ContactCreated':
+    case 'ContactUpdated':
+      await syncService.handleContactWebhook(data)
+      break
+    case 'BookingCreated':
+    case 'BookingUpdated':
+      await syncService.handleBookingWebhook(data)
+      break
+    default:
+      console.log('Unhandled webhook event:', eventType)
   }
+
+  res.status(200).json({ success: true })
 }
+
+export default withErrorHandler(handler)


### PR DESCRIPTION
## Summary
- refactor API routes to use shared error handler
- surface invalid requests with structured APIError responses

## Testing
- `npm test` *(fails: A dynamic import callback was invoked without --experimental-vm-modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bb99f6ec4c832a8f58610d4fd3cf2c