### PR TITLE
Use fallback redirect URI when Wix host mismatches

### DIFF
--- a/lib/wix-auth.js
+++ b/lib/wix-auth.js
@@ -19,24 +19,48 @@ export function resolveWixRedirectUri(fallbackRedirectUri = null) {
   }
 
   const configuredRedirectUri = publicUri || serverUri;
+  const configuredUrl = configuredRedirectUri ? safelyParseRedirectUri(configuredRedirectUri) : null;
+  const fallbackUrl = fallbackRedirectUri ? safelyParseRedirectUri(fallbackRedirectUri) : null;
 
-  if (configuredRedirectUri) {
-    try {
-      new URL(configuredRedirectUri);
-      return configuredRedirectUri;
-    } catch (error) {
+  if (configuredUrl && fallbackUrl) {
+    const configuredValue = normalizeRedirectUri(configuredUrl);
+    const fallbackValue = normalizeRedirectUri(fallbackUrl);
+
+    if (configuredValue !== fallbackValue) {
       console.warn(
-        'Invalid Wix redirect URI configuration; using fallback redirect URI instead.',
-        error
+        `Configured Wix redirect URI (${configuredValue}) does not match current host (${fallbackValue}); using fallback to prevent invalid OAuth redirects.`
       );
+      return fallbackUrl.toString();
     }
+
+    return configuredUrl.toString();
   }
 
-  if (!fallbackRedirectUri) {
+  if (configuredUrl) {
+    return configuredUrl.toString();
+  }
+
+  if (!fallbackUrl) {
     throw new Error('Missing Wix OAuth redirect URI configuration');
   }
 
-  return fallbackRedirectUri;
+  return fallbackUrl.toString();
+}
+
+function normalizeRedirectUri(url) {
+  return `${url.origin}${url.pathname}`;
+}
+
+function safelyParseRedirectUri(redirectUri) {
+  try {
+    return new URL(redirectUri);
+  } catch (error) {
+    console.warn(
+      'Invalid Wix redirect URI configuration; using fallback redirect URI instead.',
+      error
+    );
+    return null;
+  }
 }
 
 export function buildRedirectUriFromRequest(req, path = '/api/wix-oauth-callback') {


### PR DESCRIPTION
### Motivation

- Prevent invalid Wix OAuth redirects (400 errors) when the configured `NEXT_PUBLIC_WIX_REDIRECT_URI`/`WIX_REDIRECT_URI` does not match the current host.
- Avoid crashing on malformed redirect URI environment values by parsing configuration safely before use.
- Ensure comparisons ignore query string differences by normalizing redirect URIs to `origin + pathname`.

### Description

- Update `resolveWixRedirectUri` to safely parse both the configured redirect URI and the request-derived fallback and to normalize them prior to comparison.
- When the configured origin/path does not match the fallback origin/path, log a clear warning and return the fallback redirect URI to avoid invalid OAuth redirects.
- Add helper functions `safelyParseRedirectUri` and `normalizeRedirectUri`, and ensure the function always returns a string or throws when no valid URI is available.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951fdfa06e0832a9901ae7f472e5e72)